### PR TITLE
Unit 16: chunked Cashu streaming top-up

### DIFF
--- a/src/cli/commands/topup.rs
+++ b/src/cli/commands/topup.rs
@@ -1,8 +1,17 @@
 // Topup command - Extend workload lifetime with additional payment
 //
-// Unified command that works in both modes:
-//   - Nostr mode (default): sends encrypted topup to a provider via Nostr
-//   - HTTP mode (--server): calls a Paygress HTTP server directly
+// Modes:
+//   - Single-shot Nostr (default with --provider): one TopUp DM,
+//     wait for response.
+//   - Single-shot HTTP (--server): one HTTP topup call.
+//   - Streaming (--stream + --tokens-file): one TopUp DM per tick,
+//     pulling fresh tokens from the file, until exhausted or
+//     Ctrl-C. Implements R15 in its year-1 chunked form (Unit 16).
+
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use clap::Args;
@@ -19,9 +28,9 @@ pub struct TopupArgs {
     #[arg(short, long)]
     pub pod_id: String,
 
-    /// Cashu token for payment
+    /// Cashu token for payment (single-shot mode only).
     #[arg(short = 'k', long)]
-    pub token: String,
+    pub token: Option<String>,
 
     /// Provider npub (Nostr mode) - if omitted, uses --server for HTTP mode
     #[arg(long)]
@@ -38,22 +47,55 @@ pub struct TopupArgs {
     /// Custom Nostr relays (comma-separated)
     #[arg(long)]
     pub relays: Option<String>,
+
+    /// Stream chunked top-ups: one TopUp DM per tick, pulling fresh
+    /// tokens from `--tokens-file` until exhausted or Ctrl-C.
+    /// Sub-second streaming (full Cashu streaming-NUT) is out of
+    /// scope for year 1 — this is "stream sats, not stream Cashu
+    /// protocol bytes" (Unit 16).
+    #[arg(long)]
+    pub stream: bool,
+
+    /// Seconds between top-ups in streaming mode. Smaller ticks
+    /// have higher message overhead; larger ticks coarsen failover.
+    #[arg(long, default_value_t = 60)]
+    pub tick_secs: u64,
+
+    /// Path to a file with one Cashu token per line (streaming mode).
+    /// Blank lines and lines starting with `#` are ignored.
+    #[arg(long)]
+    pub tokens_file: Option<PathBuf>,
 }
 
 pub async fn execute(args: TopupArgs, verbose: bool) -> Result<()> {
+    if args.stream {
+        return execute_stream(args, verbose).await;
+    }
+
+    // Single-shot path: --token is required.
+    let token = args
+        .token
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("--token is required (or use --stream --tokens-file)"))?;
+
     if args.provider.is_some() {
         let provider = args.provider.clone().unwrap();
-        return execute_nostr_topup(provider, args, verbose).await;
+        return execute_nostr_topup(provider, args, token, verbose).await;
     }
 
     let server = args.server.clone().ok_or_else(|| {
         anyhow::anyhow!("Either --provider (Nostr) or --server (HTTP) is required")
     })?;
 
-    execute_http_topup(&server, args, verbose).await
+    execute_http_topup(&server, args, token, verbose).await
 }
 
-async fn execute_http_topup(server: &str, args: TopupArgs, verbose: bool) -> Result<()> {
+async fn execute_http_topup(
+    server: &str,
+    args: TopupArgs,
+    token: String,
+    verbose: bool,
+) -> Result<()> {
     if verbose {
         println!("{} Topping up pod via HTTP...", "->".blue());
         println!("  Server: {}", server);
@@ -67,13 +109,13 @@ async fn execute_http_topup(server: &str, args: TopupArgs, verbose: bool) -> Res
             .unwrap(),
     );
     spinner.set_message("Processing top-up payment...");
-    spinner.enable_steady_tick(std::time::Duration::from_millis(100));
+    spinner.enable_steady_tick(Duration::from_millis(100));
 
     let client = PaygressClient::new(server);
 
     let request = TopupRequest {
         pod_id: args.pod_id.clone(),
-        cashu_token: Some(args.token),
+        cashu_token: Some(token),
     };
 
     let response = client.topup_pod(request).await?;
@@ -107,7 +149,12 @@ async fn execute_http_topup(server: &str, args: TopupArgs, verbose: bool) -> Res
     Ok(())
 }
 
-async fn execute_nostr_topup(provider_npub: String, args: TopupArgs, _verbose: bool) -> Result<()> {
+async fn execute_nostr_topup(
+    provider_npub: String,
+    args: TopupArgs,
+    token: String,
+    _verbose: bool,
+) -> Result<()> {
     println!("{}", "Topping Up Workload".blue().bold());
     println!("{}", "-".repeat(50).blue());
     println!();
@@ -121,14 +168,9 @@ async fn execute_nostr_topup(provider_npub: String, args: TopupArgs, _verbose: b
     println!("  Provider: {}", provider_npub);
     println!();
 
-    // Build topup request as the structured EncryptedTopUpPodRequest
-    // payload — provider.rs uses #[serde(untagged)] PrivateRequest, so
-    // the field set must match the TopUp variant exactly. Sending a
-    // free-form JSON would silently misroute (the provider would
-    // either fail to parse or match the wrong variant).
     let request = paygress::nostr::EncryptedTopUpPodRequest {
         pod_npub: args.pod_id.clone(),
-        cashu_token: args.token,
+        cashu_token: token,
     };
 
     print!("  Sending topup request... ");
@@ -150,8 +192,6 @@ async fn execute_nostr_topup(provider_npub: String, args: TopupArgs, _verbose: b
     {
         Ok(response) => {
             println!();
-
-            // Try to parse response
             if let Ok(resp) = serde_json::from_str::<serde_json::Value>(&response.content) {
                 if resp.get("error").is_some() {
                     println!("{}", "Topup failed".red().bold());
@@ -181,4 +221,220 @@ async fn execute_nostr_topup(provider_npub: String, args: TopupArgs, _verbose: b
     }
 
     Ok(())
+}
+
+// ==================== Streaming ====================
+
+/// Read tokens from a file (one per line). Blank lines and `#`
+/// comments are ignored. Returned in file order so callers can
+/// reason about per-tick spend predictably.
+pub fn read_tokens_file(path: &std::path::Path) -> Result<Vec<String>> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("read {}: {}", path.display(), e))?;
+    Ok(raw
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(|l| l.to_string())
+        .collect())
+}
+
+/// Outcome of a streaming session, useful for tests and CLI exit
+/// reporting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamSummary {
+    pub chunks_sent: usize,
+    pub chunks_failed: usize,
+    pub exhausted: bool,
+}
+
+/// Future returned by the per-chunk send function.
+pub type SendFuture<'a> = Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + 'a>>;
+
+/// Pure streaming loop: pulls tokens off `tokens` and calls
+/// `send_one(token)` once per tick until the iterator is empty.
+/// Errors from `send_one` are counted but do not abort the loop —
+/// the user's wallet has already paid for the chunk; we don't get
+/// it back by retrying.
+///
+/// The loop is generic over the send function so unit tests can
+/// pass a mock that records calls (no Nostr / no provider needed).
+pub async fn run_stream_loop<F>(tokens: Vec<String>, tick: Duration, send_one: F) -> StreamSummary
+where
+    F: for<'a> Fn(&'a str) -> SendFuture<'a> + Send + Sync,
+{
+    let mut chunks_sent = 0usize;
+    let mut chunks_failed = 0usize;
+
+    let mut iter = tokens.into_iter();
+    while let Some(token) = iter.next() {
+        match send_one(&token).await {
+            Ok(()) => chunks_sent += 1,
+            Err(e) => {
+                chunks_failed += 1;
+                tracing::warn!("streaming top-up chunk failed: {}", e);
+            }
+        }
+        if iter.len() > 0 {
+            tokio::time::sleep(tick).await;
+        }
+    }
+
+    StreamSummary {
+        chunks_sent,
+        chunks_failed,
+        exhausted: true,
+    }
+}
+
+async fn execute_stream(args: TopupArgs, _verbose: bool) -> Result<()> {
+    let provider_npub = args.provider.clone().ok_or_else(|| {
+        anyhow::anyhow!("--stream requires --provider (HTTP streaming is not yet supported)")
+    })?;
+    let tokens_file = args
+        .tokens_file
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("--stream requires --tokens-file"))?;
+
+    let tokens = read_tokens_file(&tokens_file)?;
+    if tokens.is_empty() {
+        anyhow::bail!(
+            "--tokens-file {} contained no usable tokens",
+            tokens_file.display()
+        );
+    }
+
+    println!("{}", "Streaming Top-up".blue().bold());
+    println!("  Pod ID:   {}", args.pod_id.cyan());
+    println!("  Provider: {}", provider_npub);
+    println!(
+        "  Tokens:   {} (from {})",
+        tokens.len(),
+        tokens_file.display()
+    );
+    println!("  Tick:     {}s", args.tick_secs);
+    println!();
+
+    let relays = parse_relays(args.relays);
+    let nostr_key = get_or_create_identity(args.nostr_key)?;
+    let client = Arc::new(DiscoveryClient::new_with_key(relays, nostr_key).await?);
+    let pod_id = args.pod_id.clone();
+    let provider = provider_npub.clone();
+
+    let summary = run_stream_loop(tokens, Duration::from_secs(args.tick_secs), move |token| {
+        let client = client.clone();
+        let pod_id = pod_id.clone();
+        let provider = provider.clone();
+        let token = token.to_string();
+        Box::pin(async move {
+            let request = paygress::nostr::EncryptedTopUpPodRequest {
+                pod_npub: pod_id,
+                cashu_token: token,
+            };
+            let json = serde_json::to_string(&request)?;
+            client
+                .nostr()
+                .send_encrypted_private_message(&provider, json, "nip04")
+                .await?;
+            Ok(())
+        })
+    })
+    .await;
+
+    println!();
+    println!(
+        "{} {} chunk(s) sent, {} failed (token list exhausted)",
+        "Streaming complete:".green().bold(),
+        summary.chunks_sent,
+        summary.chunks_failed
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn read_tokens_file_skips_comments_and_blanks() {
+        use std::io::Write;
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, "# comment").unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, "  cashuA1  ").unwrap();
+        writeln!(f, "cashuA2").unwrap();
+        writeln!(f, "# trailing comment").unwrap();
+        f.flush().unwrap();
+
+        let tokens = read_tokens_file(f.path()).unwrap();
+        assert_eq!(tokens, vec!["cashuA1".to_string(), "cashuA2".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn stream_loop_invokes_send_per_token_in_order() {
+        let captured: Arc<std::sync::Mutex<Vec<String>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let cap = captured.clone();
+
+        let summary = run_stream_loop(
+            vec!["a".into(), "b".into(), "c".into()],
+            Duration::from_millis(0),
+            move |t| {
+                let cap = cap.clone();
+                let t = t.to_string();
+                Box::pin(async move {
+                    cap.lock().unwrap().push(t);
+                    Ok(())
+                })
+            },
+        )
+        .await;
+
+        assert_eq!(summary.chunks_sent, 3);
+        assert_eq!(summary.chunks_failed, 0);
+        assert!(summary.exhausted);
+        assert_eq!(*captured.lock().unwrap(), vec!["a", "b", "c"]);
+    }
+
+    #[tokio::test]
+    async fn stream_loop_counts_failures_and_keeps_going() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls2 = calls.clone();
+
+        let summary = run_stream_loop(
+            vec!["good".into(), "bad".into(), "good".into()],
+            Duration::from_millis(0),
+            move |t| {
+                let calls = calls2.clone();
+                let t = t.to_string();
+                Box::pin(async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    if t == "bad" {
+                        Err(anyhow::anyhow!("simulated transient failure"))
+                    } else {
+                        Ok(())
+                    }
+                })
+            },
+        )
+        .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+        assert_eq!(summary.chunks_sent, 2);
+        assert_eq!(summary.chunks_failed, 1);
+    }
+
+    #[tokio::test]
+    async fn stream_loop_with_empty_token_list_is_a_noop() {
+        let summary = run_stream_loop(vec![], Duration::from_secs(60), move |_t| {
+            Box::pin(async { Ok(()) })
+        })
+        .await;
+        assert_eq!(summary.chunks_sent, 0);
+        assert_eq!(summary.chunks_failed, 0);
+        assert!(summary.exhausted);
+    }
 }


### PR DESCRIPTION
**Stacked on #23 → #22 → #21.**

## Summary

Adds a streaming top-up mode to `paygress-cli topup`: one TopUp DM per tick, pulling fresh tokens off a file until exhausted or Ctrl-C. The wire protocol stays the existing single-shot TopUp DM unchanged — streaming is a CLI/SDK abstraction that says "spend a fresh small token every tick."

This is intentionally **stream sats, not stream Cashu protocol bytes.** A full Cashu streaming-NUT extension (sub-second protocol-level streaming) is a future research direction; this PR ships the practical year-1 form that works with today's mints and today's wire.

## UX

```
paygress-cli topup --pod-id <id> --provider <npub> \
                   --stream --tokens-file ./chunks.txt \
                   --tick-secs 60
```

The user pre-mints chunks (e.g. via cdk wallet, splitting one large balance into many small tokens) and lists them one-per-line in `--tokens-file`. The CLI sends one chunk per tick.

## What this PR changes

`src/cli/commands/topup.rs`:

- New flags: `--stream`, `--tokens-file <path>`, `--tick-secs <n>` (default 60). `--token` becomes optional — single-shot mode keeps working unchanged.
- `read_tokens_file(path)`: parses `#` comments and blank lines, returns tokens in file order so spend cadence is predictable.
- `run_stream_loop(tokens, tick, send_one)`: pure async loop, generic over the send function. Unit tests inject a mock that records calls and simulates failures — no Nostr / no live provider needed.
- Per-chunk send failures are **counted and logged but do not abort the loop**. Reasoning: the user's wallet has already converted the proofs into a token; halting doesn't refund. The next tick may succeed (provider flapped, relay latency).

## Tests (4 passing, inline)

- File parser skips comments + blanks
- Loop calls send fn per token in order
- Loop counts failures and keeps going (doesn't abort on a single bad chunk)
- Empty token list is a no-op (no panic, no false-positive tick)

## Test plan

- [ ] CI green
- [ ] Manual: pre-mint 5 tokens via `cashu` wallet; run with `--tick-secs 10` for one minute; observe lease extending

## Out of scope

- HTTP-server streaming (the HTTP control plane is gated behind `--features kubernetes`). `--stream` requires `--provider`.
- Live-provider integration test (manual demo).
- `--retry-window` for transient relay flapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)