### PR TITLE
Upgrade cdk 0.9 → 0.14 + nostr-sdk 0.33 → 0.43 (long-format keyset support)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "async-utility"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a349201d80b4aa18d17a34a182bdd7f8ddf845e9e57d2ea130a12e10ef1e3a47"
+checksum = "a34a3b57207a7a1007832416c3e4862378c8451b4e8e093e436f48c2d3d2c151"
 dependencies = [
  "futures-util",
  "gloo-timers",
@@ -235,41 +244,28 @@ dependencies = [
 
 [[package]]
 name = "async-wsocket"
-version = "0.5.2"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3445f8f330db8e5f3be7912f170f32e43fec90d995c71ced1ec3b8394b4a873c"
+checksum = "1c92385c7c8b3eb2de1b78aeca225212e4c9a69a78b802832759b108681a5069"
 dependencies = [
  "async-utility",
+ "futures",
  "futures-util",
- "thiserror 1.0.69",
+ "js-sys",
  "tokio",
  "tokio-rustls",
  "tokio-socks",
- "tokio-tungstenite 0.23.1",
+ "tokio-tungstenite",
  "url",
- "wasm-ws",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "async_io_stream"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
-dependencies = [
- "futures",
- "pharos",
- "rustc_version",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
 name = "atomic-destructor"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d919cb60ba95c87ba42777e9e246c4e8d658057299b437b7512531ce0a09a23"
-dependencies = [
- "tracing",
-]
+checksum = "ef49f5882e4b6afaac09ad239a4f8c70a24b8f2b0897edb1f706008efd109cf4"
 
 [[package]]
 name = "atomic-waker"
@@ -355,8 +351,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
 dependencies = [
- "bitcoin-internals 0.3.0",
- "bitcoin_hashes 0.14.1",
+ "bitcoin-internals",
+ "bitcoin_hashes",
 ]
 
 [[package]]
@@ -385,18 +381,6 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
-
-[[package]]
-name = "bech32"
-version = "0.10.0-beta"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
-
-[[package]]
-name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
@@ -407,7 +391,9 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -429,44 +415,20 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
-dependencies = [
- "bech32 0.10.0-beta",
- "bitcoin-internals 0.2.0",
- "bitcoin_hashes 0.13.0",
- "hex-conservative 0.1.2",
- "hex_lit",
- "secp256k1 0.28.2",
- "serde",
-]
-
-[[package]]
-name = "bitcoin"
 version = "0.32.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
- "bech32 0.11.1",
- "bitcoin-internals 0.3.0",
+ "bech32",
+ "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes 0.14.1",
- "hex-conservative 0.2.2",
+ "bitcoin_hashes",
+ "hex-conservative",
  "hex_lit",
- "secp256k1 0.29.1",
- "serde",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
-dependencies = [
+ "secp256k1",
  "serde",
 ]
 
@@ -491,18 +453,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
 dependencies = [
- "bitcoin-internals 0.3.0",
- "serde",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
-dependencies = [
- "bitcoin-internals 0.2.0",
- "hex-conservative 0.1.2",
+ "bitcoin-internals",
  "serde",
 ]
 
@@ -513,7 +464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
 dependencies = [
  "bitcoin-io",
- "hex-conservative 0.2.2",
+ "hex-conservative",
  "serde",
 ]
 
@@ -584,12 +535,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,14 +542,14 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cashu"
-version = "0.9.3"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c3056ce58f3c067d5eecf804f9f3c33485622aa814e03b4869d297ac79c26d"
+checksum = "d61193273b0162fa16e74712d3d5cd2c02f13ddd8bf43a545c068feabd330895"
 dependencies = [
- "bitcoin 0.32.8",
+ "bitcoin",
  "cbor-diag",
  "ciborium",
- "instant",
+ "lightning",
  "lightning-invoice",
  "once_cell",
  "regex",
@@ -613,10 +558,12 @@ dependencies = [
  "serde_with",
  "strum",
  "strum_macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "url",
  "uuid",
+ "web-time",
+ "zeroize",
 ]
 
 [[package]]
@@ -661,64 +608,76 @@ dependencies = [
 
 [[package]]
 name = "cdk"
-version = "0.9.3"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35307ced633d69ad0569dba1e03a40b54b77264c1e3eb04a0c04a313ec680298"
+checksum = "76ad7dd8cef748cd57fdf83666c390c680f88cef79d3440e2f871c7da14dcb10"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
- "bech32 0.9.1",
- "bitcoin 0.32.8",
+ "bitcoin",
  "cbor-diag",
  "cdk-common",
+ "cdk-signatory",
  "ciborium",
  "futures",
  "getrandom 0.2.17",
- "jsonwebtoken",
+ "gloo-timers",
+ "lightning",
  "lightning-invoice",
  "regex",
  "reqwest 0.12.28",
+ "ring",
+ "rustls",
  "serde",
  "serde_json",
  "serde_with",
- "sync_wrapper 0.1.2",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite",
+ "tokio-util",
  "tracing",
  "url",
  "uuid",
+ "web-time",
+ "zeroize",
 ]
 
 [[package]]
 name = "cdk-common"
-version = "0.9.3"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c319e24a44ddaa2098e939f685d29b3e009708118afcebbea99dc5e0f406690"
+checksum = "7a5427677f3b056fc6f799be8bd836ae35bad6e4123c99e3dd12972b1147c339"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitcoin 0.32.8",
+ "bitcoin",
  "cashu",
  "cbor-diag",
  "ciborium",
  "futures",
- "instant",
+ "getrandom 0.2.17",
+ "lightning",
  "lightning-invoice",
+ "parking_lot",
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "url",
  "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
 name = "cdk-redb"
-version = "0.9.3"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecdbf5ed977eedc4ceebb5317cb5026ce7cbb2db7a489f2c04d7539b8d96636"
+checksum = "bd0143f80c744bfdc56750a566ccab4402043d5bbd9a6cb1f3671f2527f8c000"
 dependencies = [
  "async-trait",
  "cdk-common",
@@ -726,9 +685,31 @@ dependencies = [
  "redb",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "cdk-signatory"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75f6d5f56de42d8948b442bc4092a2e59f9d4372fd6a17a575c374bf87cdc6a"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bip39",
+ "bitcoin",
+ "cdk-common",
+ "clap",
+ "getrandom 0.2.17",
+ "home",
+ "rustls",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1123,6 +1104,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dnssec-prover"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec4f825369fc7134da70ca4040fddc8e03b80a46d249ae38d9c1c39b7b4476bf"
+
+[[package]]
 name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,9 +1433,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1494,6 +1481,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1508,8 +1501,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash",
 ]
 
@@ -1560,12 +1551,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex-conservative"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
 name = "hex-conservative"
@@ -2111,21 +2096,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebtoken"
-version = "9.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
-dependencies = [
- "base64 0.22.1",
- "js-sys",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
 name = "k8s-openapi"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2266,26 +2236,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
-name = "lightning-invoice"
-version = "0.32.0"
+name = "libm"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ab9f6ea77e20e3129235e62a2e6bd64ed932363df104e864ee65ccffb54a8f"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "lightning"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ffe63f56b10d214be1ade8698ee80af82d981237cae3e581e7a631f5f4959f3"
 dependencies = [
- "bech32 0.9.1",
- "bitcoin 0.32.8",
+ "bech32",
+ "bitcoin",
+ "dnssec-prover",
+ "hashbrown 0.13.2",
+ "libm",
+ "lightning-invoice",
+ "lightning-types",
+ "possiblyrandom",
+]
+
+[[package]]
+name = "lightning-invoice"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
+dependencies = [
+ "bech32",
+ "bitcoin",
  "lightning-types",
  "serde",
 ]
 
 [[package]]
 name = "lightning-types"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1083b8d9137000edf3bfcb1ff011c0d25e0cdd2feb98cc21d6765e64a494148f"
+checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
 dependencies = [
- "bech32 0.9.1",
- "bitcoin 0.32.8",
- "hex-conservative 0.2.2",
+ "bitcoin",
 ]
 
 [[package]]
@@ -2299,18 +2289,6 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
-
-[[package]]
-name = "lnurl-pay"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c042191c2e3f27147decfad8182eea2c7dd1c6c1733562e25d3d401369669d"
-dependencies = [
- "bech32 0.10.0-beta",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "lock_api"
@@ -2329,12 +2307,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 
 [[package]]
 name = "lru-slab"
@@ -2415,9 +2390,9 @@ dependencies = [
 
 [[package]]
 name = "negentropy"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e664971378a3987224f7a0e10059782035e89899ae403718ee07de85bec42afe"
+checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
 
 [[package]]
 name = "nom"
@@ -2431,107 +2406,67 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.33.0"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08db214560a34bf7c4c1fea09a8461b9412bae58ba06e99ce3177d89fa1e0a6"
+checksum = "62a97d745f1bd8d5e05a978632bbb87b0614567d5142906fe7c86fb2440faac6"
 dependencies = [
  "aes",
- "base64 0.21.7",
+ "base64 0.22.1",
+ "bech32",
  "bip39",
- "bitcoin 0.31.2",
+ "bitcoin_hashes",
  "cbc",
  "chacha20",
  "chacha20poly1305",
  "getrandom 0.2.17",
  "instant",
- "js-sys",
- "negentropy",
- "once_cell",
- "reqwest 0.12.28",
  "scrypt",
+ "secp256k1",
  "serde",
  "serde_json",
- "tracing",
  "unicode-normalization",
  "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
 name = "nostr-database"
-version = "0.33.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50eebf5020d70891e3c229128de5fc73af632b651d02742383b314d3d0c7e953"
+checksum = "b1c75a8c2175d2785ba73cfddef21d1e30da5fbbdf158569b6808ba44973a15b"
 dependencies = [
- "async-trait",
  "lru",
  "nostr",
- "thiserror 1.0.69",
  "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "nostr-relay-pool"
-version = "0.33.0"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa5502a3df456790ca16d90cc688a677117d57ab56b079dcfa091390ac9f202"
+checksum = "2b2f43b70d13dfc50508a13cd902e11f4625312b2ce0e4b7c4c2283fd04001bd"
 dependencies = [
  "async-utility",
  "async-wsocket",
  "atomic-destructor",
+ "lru",
+ "negentropy",
  "nostr",
  "nostr-database",
- "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "nostr-sdk"
-version = "0.33.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b427dceefbbb49a9dd98abb8c4e40d25fdd467e99821aaad88615252bdb915bd"
+checksum = "599f8963d6a1522a13b1a2b0ea6e168acfc367706606f1d33fa595e91fa22db0"
 dependencies = [
  "async-utility",
- "atomic-destructor",
- "lnurl-pay",
  "nostr",
  "nostr-database",
  "nostr-relay-pool",
- "nostr-signer",
- "nostr-zapper",
- "nwc",
- "thiserror 1.0.69",
  "tokio",
- "tracing",
-]
-
-[[package]]
-name = "nostr-signer"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "665268b316f41cd8fa791be54b6c7935c5a239461708c380a699d6677be9af38"
-dependencies = [
- "async-utility",
- "nostr",
- "nostr-relay-pool",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "nostr-zapper"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69922e74f8eab1f9d287008c0c06acdec87277a2d8f44bd9d38e003422aea0ab"
-dependencies = [
- "async-trait",
- "nostr",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2603,20 +2538,6 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "nwc"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2e04b3edb5e9572e95b62842430625f1718e8a4a3596a30aeb04e6734764ea"
-dependencies = [
- "async-utility",
- "nostr",
- "nostr-relay-pool",
- "nostr-zapper",
- "thiserror 1.0.69",
- "tracing",
-]
 
 [[package]]
 name = "once_cell"
@@ -2852,16 +2773,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pharos"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
-dependencies = [
- "futures",
- "rustc_version",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2915,6 +2826,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "possiblyrandom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b122a615d72104fb3d8b26523fdf9232cd8ee06949fb37e4ce3ff964d15dffd"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "potential_utf"
@@ -3376,15 +3296,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3587,35 +3498,14 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
-dependencies = [
- "bitcoin_hashes 0.13.0",
- "rand 0.8.5",
- "secp256k1-sys 0.9.2",
- "serde",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes",
  "rand 0.8.5",
- "secp256k1-sys 0.10.1",
+ "secp256k1-sys",
  "serde",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -3680,12 +3570,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
-name = "send_wrapper"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
-
-[[package]]
 name = "separator"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3748,7 +3632,6 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -3886,18 +3769,6 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror 2.0.18",
- "time",
-]
 
 [[package]]
 name = "slab"
@@ -4238,22 +4109,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
-dependencies = [
- "futures-util",
- "log",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tungstenite 0.23.0",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
@@ -4265,7 +4120,8 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.26.2",
+ "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4439,26 +4295,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.8.5",
- "rustls",
- "rustls-pki-types",
- "sha1",
- "thiserror 1.0.69",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
@@ -4576,12 +4412,14 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.2.17",
- "serde",
+ "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4735,23 +4573,6 @@ dependencies = [
  "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
-]
-
-[[package]]
-name = "wasm-ws"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c5806d1b06b4f3d90d015e23364dc5d3af412ee64abba6dde8fdc01637e33"
-dependencies = [
- "async_io_stream",
- "futures",
- "js-sys",
- "pharos",
- "send_wrapper",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,11 +54,11 @@ thiserror = "1"
 rand = "0.8"
 
 # Cashu dependencies
-cdk-redb = "0.9.1"
-cdk = "0.9.0"
+cdk-redb = "0.14"
+cdk = { version = "0.14", default-features = false, features = ["wallet"] }
 
 # Nostr dependencies
-nostr-sdk = { version = "0.33", features = ["nip04", "nip44", "nip59"] }
+nostr-sdk = { version = "0.43", features = ["nip04", "nip44", "nip59"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/examples/gen_key.rs
+++ b/examples/gen_key.rs
@@ -1,0 +1,9 @@
+use nostr_sdk::{Keys, ToBech32};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let keys = Keys::generate();
+    println!("NSEC: {}", keys.secret_key().to_bech32()?);
+    println!("NPUB: {}", keys.public_key().to_bech32()?);
+    Ok(())
+}

--- a/src/blossom.rs
+++ b/src/blossom.rs
@@ -154,15 +154,17 @@ impl BlossomClient {
             .as_secs();
         let expiration = now + self.auth_ttl_secs;
 
+        let exp_str = expiration.to_string();
         let tags = vec![
-            Tag::parse(&["t", op.tag_value()])?,
-            Tag::parse(&["x", x_hash])?,
-            Tag::parse(&["expiration", &expiration.to_string()])?,
+            Tag::parse(["t", op.tag_value()])?,
+            Tag::parse(["x", x_hash])?,
+            Tag::parse(["expiration", exp_str.as_str()])?,
         ];
 
-        let event = EventBuilder::new(Kind::Custom(AUTH_KIND), "", tags)
+        let event = EventBuilder::new(Kind::Custom(AUTH_KIND), "")
+            .tags(tags)
             .custom_created_at(Timestamp::from(now))
-            .to_event(&self.keys)?;
+            .sign_with_keys(&self.keys)?;
 
         let json = serde_json::to_string(&event)?;
         Ok(format!("Nostr {}", BASE64.encode(json.as_bytes())))

--- a/src/cashu.rs
+++ b/src/cashu.rs
@@ -23,6 +23,7 @@ use cdk::cdk_database::{Error as DbError, WalletDatabase};
 use cdk::mint_url::MintUrl;
 use cdk::nuts::{CurrencyUnit, Token};
 use cdk::wallet::{ReceiveOptions, Wallet};
+use cdk::Amount;
 use tokio::sync::Mutex;
 
 const MSAT_PER_SAT: u64 = 1000;
@@ -125,14 +126,14 @@ pub async fn validate_and_redeem<R: MintRedeemer + ?Sized>(
 /// 32-byte seed.
 pub struct CdkRedeemer {
     localstore: Arc<dyn WalletDatabase<Err = DbError> + Send + Sync>,
-    seed: [u8; 32],
+    seed: [u8; 64],
     wallets: Mutex<HashMap<(String, CurrencyUnit), Arc<Wallet>>>,
 }
 
 impl CdkRedeemer {
     pub fn new(
         localstore: Arc<dyn WalletDatabase<Err = DbError> + Send + Sync>,
-        seed: [u8; 32],
+        seed: [u8; 64],
     ) -> Self {
         Self {
             localstore,
@@ -155,7 +156,7 @@ impl CdkRedeemer {
             &mint_url.to_string(),
             unit,
             self.localstore.clone(),
-            &self.seed,
+            self.seed,
             None,
         )
         .map_err(|e| RedeemError::MintError(format!("wallet construction failed: {}", e)))?;
@@ -214,14 +215,20 @@ fn map_cdk_error(e: cdk::Error) -> RedeemError {
     }
 }
 
-/// Derive a 32-byte wallet seed from the provider's Nostr private key.
-/// Uses SHA-256 with a domain separator so the wallet seed is distinct
-/// from anything else derived from the same key, and stable across
-/// process restarts.
-pub fn derive_seed_from_nostr_key(nostr_private_key: &str) -> [u8; 32] {
+/// Derive a 64-byte wallet seed from the provider's Nostr private key.
+/// cdk's `Wallet::new` requires `[u8; 64]` (BIP-39-style seed length).
+/// We hash twice with distinct domain separators so the two halves
+/// are independent.
+pub fn derive_seed_from_nostr_key(nostr_private_key: &str) -> [u8; 64] {
     use cdk::secp256k1::hashes::{sha256, Hash};
-    let preimage = format!("paygress-cashu-wallet-v1:{}", nostr_private_key);
-    sha256::Hash::hash(preimage.as_bytes()).to_byte_array()
+    let h1 =
+        sha256::Hash::hash(format!("paygress-cashu-wallet-v1:a:{}", nostr_private_key).as_bytes());
+    let h2 =
+        sha256::Hash::hash(format!("paygress-cashu-wallet-v1:b:{}", nostr_private_key).as_bytes());
+    let mut out = [0u8; 64];
+    out[..32].copy_from_slice(&h1.to_byte_array());
+    out[32..].copy_from_slice(&h2.to_byte_array());
+    out
 }
 
 /// **Legacy face-value parser.** Returns the sum of `proof.amount` from
@@ -241,18 +248,16 @@ pub async fn extract_token_value(token_str: &str) -> anyhow::Result<u64> {
     let token = Token::from_str(token_str)
         .map_err(|e| anyhow::anyhow!("Failed to decode Cashu token: {}", e))?;
 
-    if token.proofs().is_empty() {
+    // cdk 0.14 made `Token::proofs(&keysets)` require keyset metadata,
+    // but `Token::value()` still works without — it's just the sum of
+    // proof amounts. That's exactly what this legacy function does.
+    let amount: Amount = token
+        .value()
+        .map_err(|e| anyhow::anyhow!("Failed to compute token value: {}", e))?;
+    let total_amount: u64 = amount.into();
+    if total_amount == 0 {
         return Err(anyhow::anyhow!("Token has no proofs"));
     }
-
-    let total_amount: u64 = token
-        .proofs()
-        .iter()
-        .map(|p| {
-            let amt: u64 = p.amount.into();
-            amt
-        })
-        .sum();
 
     let total_amount_msats: u64 = match token.unit().unwrap_or(CurrencyUnit::Sat) {
         CurrencyUnit::Sat => total_amount * MSAT_PER_SAT,

--- a/src/cli/commands/bootstrap.rs
+++ b/src/cli/commands/bootstrap.rs
@@ -475,7 +475,6 @@ pub async fn execute(args: BootstrapArgs, verbose: bool) -> Result<()> {
             let keys = nostr_sdk::Keys::generate();
             let nsec = keys
                 .secret_key()
-                .map_err(|e| anyhow::anyhow!("Failed to get secret key: {}", e))?
                 .to_bech32()
                 .map_err(|e| anyhow::anyhow!("Failed to encode key: {}", e))?;
             let npub = keys

--- a/src/cli/commands/identity.rs
+++ b/src/cli/commands/identity.rs
@@ -51,7 +51,7 @@ pub fn get_or_create_identity(explicit_key: Option<String>) -> Result<String> {
         "  No identity found. Generating new Nostr identity...".yellow()
     );
     let keys = Keys::generate();
-    let nsec = keys.secret_key()?.to_bech32()?;
+    let nsec = keys.secret_key().to_bech32()?;
 
     // Save to file
     let mut file = std::fs::File::create(&identity_file)?;

--- a/src/cli/commands/provider.rs
+++ b/src/cli/commands/provider.rs
@@ -159,7 +159,6 @@ async fn execute_setup(args: SetupArgs, verbose: bool) -> Result<()> {
             let keys = nostr_sdk::Keys::generate();
             let nsec = keys
                 .secret_key()
-                .map_err(|e| anyhow::anyhow!("Failed to get secret key: {}", e))?
                 .to_bech32()
                 .map_err(|e| anyhow::anyhow!("Failed to encode key: {}", e))?;
             println!("  {} Generated new keypair", "✓".green());

--- a/src/nostr.rs
+++ b/src/nostr.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Result};
 use nostr_sdk::nips::nip04;
 use nostr_sdk::nips::nip59::UnwrappedGift;
 use nostr_sdk::{
-    Client, EventBuilder, Filter, Keys, Kind, RelayPoolNotification, Tag, Timestamp, ToBech32, Url,
+    Client, EventBuilder, Filter, Keys, Kind, RelayPoolNotification, Tag, Timestamp, ToBech32,
 };
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -92,14 +92,15 @@ impl NostrRelaySubscriber {
             }
         };
 
-        let client = Client::new(&keys);
+        let client = Client::new(keys.clone());
 
         // Add relays
         for relay_url in &config.relays {
             info!("Adding relay: {}", relay_url);
-            let url = Url::parse(relay_url)
+            client
+                .add_relay(relay_url)
+                .await
                 .with_context(|| format!("Invalid relay URL: {}", relay_url))?;
-            client.add_relay(url).await?;
         }
 
         info!("Connecting to {} relays...", config.relays.len());
@@ -139,10 +140,8 @@ impl NostrRelaySubscriber {
             .pubkeys(vec![self.keys.public_key()]) // Sets #p tag
             .limit(0);
 
-        let _ = self
-            .client
-            .subscribe(vec![nip04_filter, nip17_filter], None)
-            .await;
+        let _ = self.client.subscribe(nip04_filter, None).await;
+        let _ = self.client.subscribe(nip17_filter, None).await;
         info!("Subscribed to NIP-04 (Encrypted Direct Messages) and NIP-17 (Gift Wrap) messages for pod provisioning and top-up requests");
 
         // Handle incoming events
@@ -166,9 +165,9 @@ impl NostrRelaySubscriber {
                                         id: rumor.id.map(|id| id.to_hex()).unwrap_or_else(|| "unknown".to_string()),
                                         pubkey: rumor.pubkey.to_hex(),
                                         created_at: rumor.created_at.as_u64(),
-                                        kind: rumor.kind.as_u32(),
+                                        kind: rumor.kind.as_u16() as u32,
                                         tags: rumor.tags.iter().map(|tag| {
-                                            tag.as_vec().iter().map(|s| s.to_string()).collect()
+                                            tag.as_slice().iter().map(|s| s.to_string()).collect()
                                         }).collect(),
                                         content: rumor.content,
                                         sig: "unsigned".to_string(), // UnsignedEvent doesn't have a signature
@@ -195,43 +194,50 @@ impl NostrRelaySubscriber {
                     Kind::EncryptedDirectMessage => {
                         info!("Received NIP-04 Encrypted Direct Message: {}", event.id);
 
-                        // Decrypt the NIP-04 message using NIP-04 module
-                        match self.keys.secret_key() {
-                            Ok(secret_key) => {
-                                match nip04::decrypt(&secret_key, &event.pubkey, &event.content) {
-                                    Ok(decrypted_content) => {
-                                        debug!("Decrypted NIP-04 message. Length: {}", decrypted_content.len());
+                        let secret_key = self.keys.secret_key();
+                        match nip04::decrypt(secret_key, &event.pubkey, &event.content) {
+                            Ok(decrypted_content) => {
+                                debug!(
+                                    "Decrypted NIP-04 message. Length: {}",
+                                    decrypted_content.len()
+                                );
 
-                                        // Create a NostrEvent from the decrypted message with NIP-04 flag
-                                        let nostr_event = NostrEvent {
-                                            id: event.id.to_hex(),
-                                            pubkey: event.pubkey.to_hex(),
-                                            created_at: event.created_at.as_u64(),
-                                            kind: event.kind.as_u32(),
-                                            tags: event.tags.iter().map(|tag| {
-                                                tag.as_vec().iter().map(|s| s.to_string()).collect()
-                                            }).collect(),
-                                            content: decrypted_content,
-                                            sig: event.sig.to_string(),
-                                            message_type: "nip04".to_string(), // Flag to indicate NIP-04
-                                        };
+                                let nostr_event = NostrEvent {
+                                    id: event.id.to_hex(),
+                                    pubkey: event.pubkey.to_hex(),
+                                    created_at: event.created_at.as_u64(),
+                                    kind: event.kind.as_u16() as u32,
+                                    tags: event
+                                        .tags
+                                        .iter()
+                                        .map(|tag| {
+                                            tag.as_slice()
+                                                .iter()
+                                                .map(|s| s.to_string())
+                                                .collect()
+                                        })
+                                        .collect(),
+                                    content: decrypted_content,
+                                    sig: event.sig.to_string(),
+                                    message_type: "nip04".to_string(),
+                                };
 
-                                        match handler(nostr_event).await {
-                                            Ok(()) => {
-                                                info!("Successfully processed NIP-04 private message: {}", event.id);
-                                            }
-                                            Err(e) => {
-                                                error!("Failed to process NIP-04 private message {}: {}", event.id, e);
-                                            }
-                                        }
-                                    }
-                                    Err(e) => {
-                                        error!("Failed to decrypt NIP-04 message {}: {}", event.id, e);
-                                    }
+                                match handler(nostr_event).await {
+                                    Ok(()) => info!(
+                                        "Successfully processed NIP-04 private message: {}",
+                                        event.id
+                                    ),
+                                    Err(e) => error!(
+                                        "Failed to process NIP-04 private message {}: {}",
+                                        event.id, e
+                                    ),
                                 }
                             }
                             Err(e) => {
-                                error!("Failed to get secret key for NIP-04 decryption: {}", e);
+                                error!(
+                                    "Failed to decrypt NIP-04 message {}: {}",
+                                    event.id, e
+                                );
                             }
                         }
                     }
@@ -253,14 +259,15 @@ impl NostrRelaySubscriber {
         let tags = vec![Tag::hashtag("paygress"), Tag::hashtag("offer")];
 
         info!("Creating event with kind 999 and {} tags", tags.len());
-        let builder = EventBuilder::new(Kind::Custom(999), content, tags);
-        let event = builder.to_event(&self.keys)?;
+        let event = EventBuilder::new(Kind::Custom(999), content)
+            .tags(tags)
+            .sign_with_keys(&self.keys)?;
         let event_id = event.id.to_hex();
 
         info!("Event created with ID: {}", event_id);
         info!("Sending offer event to relays: {}", event_id);
 
-        match self.client.send_event(event).await {
+        match self.client.send_event(&event).await {
             Ok(res) => {
                 info!(
                     "✅ Successfully published offer event: {} and {:?}",
@@ -285,36 +292,28 @@ impl NostrRelaySubscriber {
         let receiver_pubkey_parsed = nostr_sdk::PublicKey::parse(receiver_pubkey)?;
 
         match message_type {
-            "nip04" => match self.keys.secret_key() {
-                Ok(secret_key) => {
-                    let encrypted_content =
-                        nip04::encrypt(&secret_key, &receiver_pubkey_parsed, &content)?;
-                    let receiver_tag = Tag::public_key(receiver_pubkey_parsed);
-                    let alt_tag = Tag::parse(&["alt", "Private Message"])?;
+            "nip04" => {
+                let secret_key = self.keys.secret_key();
+                let encrypted_content =
+                    nip04::encrypt(secret_key, &receiver_pubkey_parsed, &content)?;
+                let receiver_tag = Tag::public_key(receiver_pubkey_parsed);
+                let alt_tag = Tag::parse(["alt", "Private Message"])?;
 
-                    let event_builder = EventBuilder::new(
-                        Kind::EncryptedDirectMessage,
-                        encrypted_content,
-                        [receiver_tag, alt_tag],
-                    );
-                    let event = event_builder.to_event(&self.keys)?;
-                    let event_id = self.client.send_event(event).await?;
-                    info!("Sent NIP-04 message to {}: {:?}", receiver_pubkey, event_id);
-                    Ok(event_id.to_hex())
-                }
-                Err(e) => {
-                    error!("Failed to get secret key for NIP-04 encryption: {}", e);
-                    Err(e.into())
-                }
-            },
+                let event = EventBuilder::new(Kind::EncryptedDirectMessage, encrypted_content)
+                    .tags([receiver_tag, alt_tag])
+                    .sign_with_keys(&self.keys)?;
+                let event_id = self.client.send_event(&event).await?;
+                info!("Sent NIP-04 message to {}: {:?}", receiver_pubkey, event_id);
+                Ok(event_id.val.to_hex())
+            }
             "nip17" | _ => {
                 // Default to NIP-17 if not specified or nip17
                 let event_id = self
                     .client
-                    .send_private_msg(receiver_pubkey_parsed, content, None)
+                    .send_private_msg(receiver_pubkey_parsed, content, [])
                     .await?;
                 info!("Sent NIP-17 message to {}: {:?}", receiver_pubkey, event_id);
-                Ok(event_id.to_hex())
+                Ok(event_id.val.to_hex())
             }
         }
     }
@@ -395,20 +394,21 @@ impl NostrRelaySubscriber {
         self.keys.public_key().to_hex()
     }
 
+    #[allow(dead_code)]
     fn convert_event(&self, event: &nostr_sdk::Event) -> NostrEvent {
         NostrEvent {
             id: event.id.to_hex(),
             pubkey: event.pubkey.to_hex(),
             created_at: event.created_at.as_u64(),
-            kind: event.kind.as_u32(),
+            kind: event.kind.as_u16() as u32,
             tags: event
                 .tags
                 .iter()
-                .map(|tag| tag.as_vec().iter().map(|s| s.to_string()).collect())
+                .map(|tag| tag.as_slice().iter().map(|s| s.to_string()).collect())
                 .collect(),
             content: event.content.clone(),
             sig: event.sig.to_string(),
-            message_type: "unknown".to_string(), // Default value since this function doesn't know the context
+            message_type: "unknown".to_string(),
         }
     }
 
@@ -432,7 +432,7 @@ impl NostrRelaySubscriber {
             .pubkeys(vec![receiver_pk])
             .kinds(vec![Kind::EncryptedDirectMessage, Kind::GiftWrap]);
 
-        let _ = client.subscribe(vec![filter], None).await;
+        let _ = client.subscribe(filter, None).await;
 
         // Use tokio::select to handle timeout and notification processing
         let result = tokio::select! {
@@ -455,8 +455,8 @@ impl NostrRelaySubscriber {
                                             id: rumor.id.map(|id| id.to_hex()).unwrap_or_default(),
                                             pubkey: sender.to_hex(),
                                             created_at: rumor.created_at.as_u64(),
-                                            kind: rumor.kind.as_u32(),
-                                            tags: rumor.tags.iter().map(|tag| tag.as_vec().iter().map(|s| s.to_string()).collect()).collect(),
+                                            kind: rumor.kind.as_u16() as u32,
+                                            tags: rumor.tags.iter().map(|tag| tag.as_slice().iter().map(|s| s.to_string()).collect()).collect(),
                                             content: rumor.content,
                                             sig: String::new(),
                                             message_type: "nip17".to_string(),
@@ -466,19 +466,18 @@ impl NostrRelaySubscriber {
                             }
                             Kind::EncryptedDirectMessage => {
                                 if event.pubkey == sender_pk {
-                                    if let Ok(secret_key) = receiver_keys.secret_key() {
-                                        if let Ok(content) = nip04::decrypt(&secret_key, &event.pubkey, &event.content) {
-                                            event_to_send = Some(NostrEvent {
-                                                id: event.id.to_hex(),
-                                                pubkey: event.pubkey.to_hex(),
-                                                created_at: event.created_at.as_u64(),
-                                                kind: event.kind.as_u32(),
-                                                tags: event.tags.iter().map(|tag| tag.as_vec().iter().map(|s| s.to_string()).collect()).collect(),
-                                                content,
-                                                sig: event.sig.to_string(),
-                                                message_type: "nip04".to_string(),
-                                            });
-                                        }
+                                    let secret_key = receiver_keys.secret_key();
+                                    if let Ok(content) = nip04::decrypt(secret_key, &event.pubkey, &event.content) {
+                                        event_to_send = Some(NostrEvent {
+                                            id: event.id.to_hex(),
+                                            pubkey: event.pubkey.to_hex(),
+                                            created_at: event.created_at.as_u64(),
+                                            kind: event.kind.as_u16() as u32,
+                                            tags: event.tags.iter().map(|tag| tag.as_slice().iter().map(|s| s.to_string()).collect()).collect(),
+                                            content,
+                                            sig: event.sig.to_string(),
+                                            message_type: "nip04".to_string(),
+                                        });
                                     }
                                 }
                             }
@@ -601,10 +600,10 @@ pub async fn send_provisioning_request_private_message(
     // Send as private message
     let service_pubkey_parsed = nostr_sdk::PublicKey::parse(service_pubkey)?;
     let event_id = client
-        .send_private_msg(service_pubkey_parsed, request_json, None)
+        .send_private_msg(service_pubkey_parsed, request_json, [])
         .await?;
 
-    Ok(event_id.to_hex())
+    Ok(event_id.val.to_hex())
 }
 
 // NEW: Helper function to parse private message content
@@ -751,15 +750,16 @@ impl NostrRelaySubscriber {
         let tags = vec![
             Tag::hashtag("paygress"),
             Tag::hashtag("compute"),
-            Tag::parse(&["d", &d_tag])?,
-            Tag::parse(&["v", &offer.version.to_string()])?,
+            Tag::parse(["d", d_tag.as_str()])?,
+            Tag::parse(["v", offer.version.to_string().as_str()])?,
         ];
 
-        let builder = EventBuilder::new(Kind::Custom(KIND_PROVIDER_OFFER), content, tags);
-        let event = builder.to_event(&self.keys)?;
+        let event = EventBuilder::new(Kind::Custom(KIND_PROVIDER_OFFER), content)
+            .tags(tags)
+            .sign_with_keys(&self.keys)?;
         let event_id = event.id.to_hex();
 
-        match self.client.send_event(event).await {
+        match self.client.send_event(&event).await {
             Ok(res) => {
                 info!("✅ Published provider offer: {} ({:?})", event_id, res);
                 Ok(event_id)
@@ -797,15 +797,13 @@ impl NostrRelaySubscriber {
         let stored_tags = vec![
             Tag::hashtag("paygress-heartbeat"),
             Tag::public_key(provider_pk),
-            Tag::parse(&["d", &d_tag])?,
-            Tag::parse(&["v", &v_tag])?,
+            Tag::parse(["d", d_tag.as_str()])?,
+            Tag::parse(["v", v_tag.as_str()])?,
         ];
-        let stored = EventBuilder::new(
-            Kind::Custom(KIND_PROVIDER_HEARTBEAT),
-            content.clone(),
-            stored_tags,
-        );
-        let stored_event = stored.to_event(&self.keys)?;
+        let stored_event =
+            EventBuilder::new(Kind::Custom(KIND_PROVIDER_HEARTBEAT), content.clone())
+                .tags(stored_tags)
+                .sign_with_keys(&self.keys)?;
         let stored_id = stored_event.id.to_hex();
 
         // 2. Ephemeral: relays don't store, but live subscribers see
@@ -813,20 +811,18 @@ impl NostrRelaySubscriber {
         let ephemeral_tags = vec![
             Tag::hashtag("paygress-heartbeat"),
             Tag::public_key(provider_pk),
-            Tag::parse(&["v", &v_tag])?,
+            Tag::parse(["v", v_tag.as_str()])?,
         ];
-        let ephemeral = EventBuilder::new(
-            Kind::Custom(KIND_PROVIDER_HEARTBEAT_EPHEMERAL),
-            content,
-            ephemeral_tags,
-        );
-        let ephemeral_event = ephemeral.to_event(&self.keys)?;
+        let ephemeral_event =
+            EventBuilder::new(Kind::Custom(KIND_PROVIDER_HEARTBEAT_EPHEMERAL), content)
+                .tags(ephemeral_tags)
+                .sign_with_keys(&self.keys)?;
 
-        match self.client.send_event(stored_event).await {
+        match self.client.send_event(&stored_event).await {
             Ok(_) => debug!("📦 Stored heartbeat published: {}", stored_id),
             Err(e) => warn!("Failed to publish stored heartbeat: {}", e),
         }
-        match self.client.send_event(ephemeral_event).await {
+        match self.client.send_event(&ephemeral_event).await {
             Ok(_) => debug!("⚡ Ephemeral heartbeat published"),
             Err(e) => warn!("Failed to publish ephemeral heartbeat: {}", e),
         }
@@ -843,7 +839,7 @@ impl NostrRelaySubscriber {
 
         let events = self
             .client
-            .get_events_of(vec![filter], Some(std::time::Duration::from_secs(5)))
+            .fetch_events(filter, std::time::Duration::from_secs(5))
             .await?;
 
         let mut providers = Vec::new();
@@ -875,7 +871,7 @@ impl NostrRelaySubscriber {
 
         let events = self
             .client
-            .get_events_of(vec![filter], Some(std::time::Duration::from_secs(5)))
+            .fetch_events(filter, std::time::Duration::from_secs(5))
             .await?;
 
         let mut heartbeats = Vec::new();
@@ -916,7 +912,7 @@ impl NostrRelaySubscriber {
 
         let events = self
             .client
-            .get_events_of(vec![filter], Some(std::time::Duration::from_secs(3)))
+            .fetch_events(filter, std::time::Duration::from_secs(3))
             .await?;
 
         if let Some(event) = events.first() {
@@ -962,7 +958,7 @@ impl NostrRelaySubscriber {
         // Use a short timeout of 3 seconds for fast feedback
         let events = self
             .client
-            .get_events_of(vec![filter], Some(std::time::Duration::from_secs(3)))
+            .fetch_events(filter, std::time::Duration::from_secs(3))
             .await?;
 
         let mut heartbeats = std::collections::HashMap::new();

--- a/src/pod_provisioning.rs
+++ b/src/pod_provisioning.rs
@@ -434,7 +434,7 @@ impl PodProvisioningService {
         // Generate NPUB first and use it as pod name
         let pod_keys = Keys::generate();
         let pod_npub = pod_keys.public_key().to_bech32().unwrap();
-        let pod_nsec = pod_keys.secret_key().unwrap().to_secret_hex();
+        let pod_nsec = pod_keys.secret_key().to_secret_hex();
 
         // Create Kubernetes-safe pod name from NPUB (take first 8 chars after npub1 prefix)
         let pod_name = format!(

--- a/tests/cashu_redemption.rs
+++ b/tests/cashu_redemption.rs
@@ -106,7 +106,12 @@ impl MintRedeemer for MockRedeemer {
         use std::str::FromStr;
         let token = cdk::nuts::Token::from_str(token_str)
             .map_err(|e| RedeemError::InvalidToken(e.to_string()))?;
-        let total: u64 = token.proofs().iter().map(|p| u64::from(p.amount)).sum();
+        // cdk 0.14: Token::value() returns the proof-amount sum without
+        // requiring keyset metadata. We're not redeeming, just summing.
+        let amount = token
+            .value()
+            .map_err(|e| RedeemError::InvalidToken(e.to_string()))?;
+        let total: u64 = amount.into();
         let unit = token.unit().unwrap_or(cdk::nuts::CurrencyUnit::Sat);
         let msats = match unit {
             cdk::nuts::CurrencyUnit::Sat => total * 1000,


### PR DESCRIPTION
**Stacked on #27.** Closes #28.

## Summary

Bumps the two largest crypto deps to versions that support the new long-format Cashu keyset IDs:

- `cdk` 0.9.0 → 0.14
- `cdk-redb` 0.9.1 → 0.14
- **Cascading: `nostr-sdk` 0.33 → 0.43** (cdk 0.14 transitively requires it)

The previous pinned versions only understood legacy 16-char keyset IDs; every modern public Cashu mint (including `https://testnut.cashu.space`, the canonical free-token test mint) has migrated to long-format 66-char IDs. Without this upgrade, `Wallet::receive` against any modern mint fails with `NoActiveKeyset` because every keyset gets filtered as unparseable.

## API surface changes

### `nostr-sdk` 0.33 → 0.43

| Before | After |
|--------|-------|
| `EventBuilder::new(kind, content, tags)` | `EventBuilder::new(kind, content).tags(tags)` |
| `.to_event(&keys)` | `.sign_with_keys(&keys)` |
| `Tag::parse(&[...])` | `Tag::parse([...])` (no `&` on slice) |
| `Kind::as_u32()` | `as_u16()` then cast |
| `Tag::as_vec()` | `as_slice()` |
| `Client::new(&keys)` | `Client::new(keys.clone())` |
| `client.get_events_of(filters, opt_timeout)` | `fetch_events(filter, timeout)` (single filter) |
| `client.subscribe(vec![f1, f2], None)` | multiple `.subscribe(f, None)` calls |
| `client.send_private_msg(.., None)` | `send_private_msg(.., [])` |
| `client.send_event(event)` | `send_event(&event)` |
| `Keys::secret_key() -> Result<&SecretKey, _>` | `Keys::secret_key() -> &SecretKey` |
| `Url::parse(url) → client.add_relay(url)` | `client.add_relay(url_str)` |
| `EventId` from send | `Output<EventId>` — id is in `.val` |

### `cdk` 0.9 → 0.14

| Before | After |
|--------|-------|
| `Wallet::new(.., seed: &[u8], ..)` (32 bytes) | `Wallet::new(.., seed: [u8; 64], ..)` |
| `token.proofs() -> Proofs` | `token.proofs(&keysets) -> Result<Proofs, _>` |
| `derive_seed_from_nostr_key -> [u8; 32]` | `[u8; 64]` via two SHA-256 rounds with distinct domain separators |

The legacy `extract_token_value` face-value parser switched from `token.proofs().iter().sum()` to `token.value()` which doesn't need keysets — it's just summing proof amounts. Same numerical result.

## Behaviour preserved

All 78 existing tests pass on the new deps with no test changes other than the `cashu_redemption.rs` mock's switch to `Token::value()`. Heartbeat schema, replay-protection logic, deploy CLI, streaming top-up, observatory aggregator, stake verification — all green.

## What this unblocks

The `Id::try_from` validation in `cashu` 0.14 accepts both legacy v1 (`STRLEN_V1 + 2 = 16`) and new v2 (`STRLEN_V2 + 2 = 66`) keyset IDs. testnut's keysets now parse.

## What's still in the way

The end-to-end mint-quote → mint flow against testnut hits a separate cdk 0.14 self-validation error: `Keyset id incorrect`. cdk recomputes the ID from the returned keys and compares it to the keyset's claimed ID; for testnut's current responses they disagree. **This is a different error than before** (was `NoActiveKeyset` from the length filter; now it's an internal cdk consistency check failing). Out of scope for this PR.

Three follow-up paths — none small enough to add here:

1. Bump cdk again to 0.16. The `WalletDatabase` trait was reshaped (now generic over `Err` rather than via associated type) and `mint_quote` gained two new args (`method`, `extra`). Significant additional refactor.
2. Run a self-hosted nutshell mint pinned to a version whose responses don't trip cdk 0.14's internal consistency check.
3. Upstream issue at the cdk repo.

## Verification

- `cargo build` (default) clean
- `cargo build --features kubernetes` clean
- `cargo test` — **78 tests pass across 9 suites**
- `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)