### PR TITLE
feat(cli/mcp): add workload_status + topup_workload tools

### DIFF
--- a/src/cli/commands/mcp.rs
+++ b/src/cli/commands/mcp.rs
@@ -35,6 +35,8 @@ use serde::{Deserialize, Serialize};
 use super::batch;
 use super::identity::{get_or_create_identity, parse_relays};
 use super::spawn::{nostr_spawn_round_trip, NostrSpawnOutcome};
+use super::status::{nostr_status_round_trip, NostrStatusOutcome};
+use super::topup::{nostr_topup_round_trip, NostrTopupOutcome};
 use paygress::discovery::DiscoveryClient;
 use paygress::nostr::ProviderFilter;
 
@@ -157,6 +159,37 @@ pub struct BatchParams {
 
 fn default_batch_template() -> String {
     "agent-sandbox".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct StatusParams {
+    /// Provider npub that owns the workload.
+    pub provider: String,
+    /// Pod identifier from the spawn response (e.g.
+    /// "container-1042").
+    pub pod_id: String,
+    /// Per-call timeout in seconds.
+    #[serde(default = "default_status_timeout_secs")]
+    pub timeout_secs: u64,
+}
+
+fn default_status_timeout_secs() -> u64 {
+    30
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TopupParams {
+    /// Provider npub that owns the workload.
+    pub provider: String,
+    /// Pod identifier from the spawn response.
+    pub pod_id: String,
+    /// Cashu token paying for the lease extension. The provider
+    /// applies `redeemed_amount / rate_msats_per_sec` seconds of
+    /// extension on success.
+    pub token: String,
+    /// Per-call timeout in seconds.
+    #[serde(default = "default_timeout_secs")]
+    pub timeout_secs: u64,
 }
 
 #[tool_router]
@@ -412,6 +445,102 @@ impl PaygressMcpServer {
             serde_json::to_string_pretty(&manifest).unwrap_or_else(|_| "{}".to_string()),
         )]))
     }
+
+    #[tool(
+        description = "Get the current status of an existing Paygress workload by pod_id. Returns expiry, time-remaining, ssh host/port, and resource allocation. Use this to monitor a lease before it expires so you can call `topup_workload` proactively."
+    )]
+    async fn workload_status(
+        &self,
+        Parameters(params): Parameters<StatusParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let relays = self.resolve_relays();
+        let nostr_key = self.resolve_nostr_key()?;
+
+        let outcome = nostr_status_round_trip(
+            &params.pod_id,
+            &params.provider,
+            relays,
+            nostr_key,
+            params.timeout_secs,
+        )
+        .await
+        .map_err(|e| McpError::internal_error(format!("status: {}", e), None))?;
+
+        let body = match outcome {
+            NostrStatusOutcome::Success(s) => serde_json::json!({
+                "status": "ok",
+                "pod_id": s.pod_id,
+                "lease_status": s.status,
+                "expires_at": s.expires_at,
+                "time_remaining_seconds": s.time_remaining_seconds,
+                "cpu_millicores": s.cpu_millicores,
+                "memory_mb": s.memory_mb,
+                "ssh_host": s.ssh_host,
+                "ssh_port": s.ssh_port,
+                "ssh_username": s.ssh_username,
+            }),
+            NostrStatusOutcome::UnparseableResponse(content) => serde_json::json!({
+                "status": "unknown_response",
+                "content": content,
+            }),
+            NostrStatusOutcome::Timeout => serde_json::json!({
+                "status": "timeout",
+                "message": "provider did not respond within the timeout window",
+            }),
+        };
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&body).unwrap_or_else(|_| "{}".to_string()),
+        )]))
+    }
+
+    #[tool(
+        description = "Extend an existing Paygress workload's lease by paying the provider with another Cashu token. The provider redeems the token at the mint and adds `redeemed_amount / rate_msats_per_sec` seconds to the lease. Returns the new expiry on success or a structured provider error (lease_expired, not_owner, insufficient_payment, race_lost, etc.) on failure."
+    )]
+    async fn topup_workload(
+        &self,
+        Parameters(params): Parameters<TopupParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let relays = self.resolve_relays();
+        let nostr_key = self.resolve_nostr_key()?;
+
+        let outcome = nostr_topup_round_trip(
+            &params.pod_id,
+            &params.token,
+            &params.provider,
+            relays,
+            nostr_key,
+            params.timeout_secs,
+        )
+        .await
+        .map_err(|e| McpError::internal_error(format!("topup: {}", e), None))?;
+
+        let body = match outcome {
+            NostrTopupOutcome::Success(r) => serde_json::json!({
+                "status": "ok",
+                "pod_id": r.pod_npub,
+                "extended_duration_seconds": r.extended_duration_seconds,
+                "new_expires_at": r.new_expires_at,
+                "message": r.message,
+            }),
+            NostrTopupOutcome::ProviderError(err) => serde_json::json!({
+                "status": "provider_error",
+                "error_type": err.error_type,
+                "message": err.message,
+                "details": err.details,
+            }),
+            NostrTopupOutcome::UnknownResponse(content) => serde_json::json!({
+                "status": "unknown_response",
+                "content": content,
+            }),
+            NostrTopupOutcome::Timeout => serde_json::json!({
+                "status": "timeout",
+                "message": "provider did not respond within the timeout window — token MAY have been spent; call workload_status to verify before retrying"
+            }),
+        };
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&body).unwrap_or_else(|_| "{}".to_string()),
+        )]))
+    }
 }
 
 #[tool_handler]
@@ -420,10 +549,11 @@ impl ServerHandler for PaygressMcpServer {
         ServerInfo {
             instructions: Some(
                 "Paygress: pay-per-use compute marketplace using Cashu ecash and Nostr. \
-                 Use `list_providers` to discover providers, `spawn_workload` to pay for a \
-                 single ephemeral container, and `batch_spawn` for parallel N-shard fan-out. \
-                 The agent connects to the returned host:ssh_port itself for the actual \
-                 exec — Paygress is the spawn/billing fabric, not the exec channel."
+                 Lifecycle: `list_providers` (discover) → `spawn_workload` (single) or \
+                 `batch_spawn` (N-shard fan-out) → `workload_status` (monitor) → \
+                 `topup_workload` (extend before expiry). The agent connects to the \
+                 returned host:ssh_port itself to actually run code — Paygress is the \
+                 spawn/billing/lifecycle fabric, not the exec channel."
                     .to_string(),
             ),
             capabilities: ServerCapabilities::builder().enable_tools().build(),
@@ -452,11 +582,13 @@ mod tests {
         let server = PaygressMcpServer::new(McpArgs::default());
         let info = server.get_info();
         assert!(info.capabilities.tools.is_some());
-        assert!(info
-            .instructions
-            .as_deref()
-            .unwrap_or("")
-            .contains("Paygress"));
+        let inst = info.instructions.as_deref().unwrap_or("");
+        assert!(inst.contains("Paygress"));
+        // Pin the lifecycle hint so future edits don't drop the
+        // workload_status / topup_workload mentions — agents rely on
+        // these to know when to call them.
+        assert!(inst.contains("workload_status"));
+        assert!(inst.contains("topup_workload"));
     }
 
     #[test]
@@ -485,6 +617,29 @@ mod tests {
         assert_eq!(v.template, "agent-sandbox");
         assert_eq!(v.tier, "basic");
         assert_eq!(v.tokens.as_ref().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn status_params_defaults_round_trip() {
+        let v = serde_json::from_value::<StatusParams>(serde_json::json!({
+            "provider": "npub1abc",
+            "pod_id": "container-7",
+        }))
+        .unwrap();
+        assert_eq!(v.timeout_secs, 30);
+        assert_eq!(v.pod_id, "container-7");
+    }
+
+    #[test]
+    fn topup_params_defaults_round_trip() {
+        let v = serde_json::from_value::<TopupParams>(serde_json::json!({
+            "provider": "npub1abc",
+            "pod_id": "container-7",
+            "token": "tok",
+        }))
+        .unwrap();
+        assert_eq!(v.timeout_secs, 120);
+        assert_eq!(v.token, "tok");
     }
 
     #[test]

--- a/src/cli/commands/mcp.rs
+++ b/src/cli/commands/mcp.rs
@@ -35,6 +35,8 @@ use serde::{Deserialize, Serialize};
 use super::batch;
 use super::identity::{get_or_create_identity, parse_relays};
 use super::spawn::{nostr_spawn_round_trip, NostrSpawnOutcome};
+use super::status::{nostr_status_round_trip, NostrStatusOutcome};
+use super::topup::{nostr_topup_round_trip, NostrTopupOutcome};
 use paygress::discovery::DiscoveryClient;
 use paygress::nostr::ProviderFilter;
 
@@ -157,6 +159,37 @@ pub struct BatchParams {
 
 fn default_batch_template() -> String {
     "agent-sandbox".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct StatusParams {
+    /// Provider npub that owns the workload.
+    pub provider: String,
+    /// Pod identifier from the spawn response (e.g.
+    /// "container-1042").
+    pub pod_id: String,
+    /// Per-call timeout in seconds.
+    #[serde(default = "default_status_timeout_secs")]
+    pub timeout_secs: u64,
+}
+
+fn default_status_timeout_secs() -> u64 {
+    30
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TopupParams {
+    /// Provider npub that owns the workload.
+    pub provider: String,
+    /// Pod identifier from the spawn response.
+    pub pod_id: String,
+    /// Cashu token paying for the lease extension. The provider
+    /// applies `redeemed_amount / rate_msats_per_sec` seconds of
+    /// extension on success.
+    pub token: String,
+    /// Per-call timeout in seconds.
+    #[serde(default = "default_timeout_secs")]
+    pub timeout_secs: u64,
 }
 
 #[tool_router]
@@ -406,6 +439,98 @@ impl PaygressMcpServer {
             serde_json::to_string_pretty(&manifest).unwrap_or_else(|_| "{}".to_string()),
         )]))
     }
+
+    #[tool(description = "Get the current status of an existing Paygress workload by pod_id. Returns expiry, time-remaining, ssh host/port, and resource allocation. Use this to monitor a lease before it expires so you can call `topup_workload` proactively.")]
+    async fn workload_status(
+        &self,
+        Parameters(params): Parameters<StatusParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let relays = self.resolve_relays();
+        let nostr_key = self.resolve_nostr_key()?;
+
+        let outcome = nostr_status_round_trip(
+            &params.pod_id,
+            &params.provider,
+            relays,
+            nostr_key,
+            params.timeout_secs,
+        )
+        .await
+        .map_err(|e| McpError::internal_error(format!("status: {}", e), None))?;
+
+        let body = match outcome {
+            NostrStatusOutcome::Success(s) => serde_json::json!({
+                "status": "ok",
+                "pod_id": s.pod_id,
+                "lease_status": s.status,
+                "expires_at": s.expires_at,
+                "time_remaining_seconds": s.time_remaining_seconds,
+                "cpu_millicores": s.cpu_millicores,
+                "memory_mb": s.memory_mb,
+                "ssh_host": s.ssh_host,
+                "ssh_port": s.ssh_port,
+                "ssh_username": s.ssh_username,
+            }),
+            NostrStatusOutcome::UnparseableResponse(content) => serde_json::json!({
+                "status": "unknown_response",
+                "content": content,
+            }),
+            NostrStatusOutcome::Timeout => serde_json::json!({
+                "status": "timeout",
+                "message": "provider did not respond within the timeout window",
+            }),
+        };
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&body).unwrap_or_else(|_| "{}".to_string()),
+        )]))
+    }
+
+    #[tool(description = "Extend an existing Paygress workload's lease by paying the provider with another Cashu token. The provider redeems the token at the mint and adds `redeemed_amount / rate_msats_per_sec` seconds to the lease. Returns the new expiry on success or a structured provider error (lease_expired, not_owner, insufficient_payment, race_lost, etc.) on failure.")]
+    async fn topup_workload(
+        &self,
+        Parameters(params): Parameters<TopupParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let relays = self.resolve_relays();
+        let nostr_key = self.resolve_nostr_key()?;
+
+        let outcome = nostr_topup_round_trip(
+            &params.pod_id,
+            &params.token,
+            &params.provider,
+            relays,
+            nostr_key,
+            params.timeout_secs,
+        )
+        .await
+        .map_err(|e| McpError::internal_error(format!("topup: {}", e), None))?;
+
+        let body = match outcome {
+            NostrTopupOutcome::Success(r) => serde_json::json!({
+                "status": "ok",
+                "pod_id": r.pod_npub,
+                "extended_duration_seconds": r.extended_duration_seconds,
+                "new_expires_at": r.new_expires_at,
+                "message": r.message,
+            }),
+            NostrTopupOutcome::ProviderError(err) => serde_json::json!({
+                "status": "provider_error",
+                "error_type": err.error_type,
+                "message": err.message,
+                "details": err.details,
+            }),
+            NostrTopupOutcome::UnknownResponse(content) => serde_json::json!({
+                "status": "unknown_response",
+                "content": content,
+            }),
+            NostrTopupOutcome::Timeout => serde_json::json!({
+                "status": "timeout",
+                "message": "provider did not respond within the timeout window — token MAY have been spent; call workload_status to verify before retrying"
+            }),
+        };
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&body).unwrap_or_else(|_| "{}".to_string()),
+        )]))
+    }
 }
 
 #[tool_handler]
@@ -414,10 +539,11 @@ impl ServerHandler for PaygressMcpServer {
         ServerInfo {
             instructions: Some(
                 "Paygress: pay-per-use compute marketplace using Cashu ecash and Nostr. \
-                 Use `list_providers` to discover providers, `spawn_workload` to pay for a \
-                 single ephemeral container, and `batch_spawn` for parallel N-shard fan-out. \
-                 The agent connects to the returned host:ssh_port itself for the actual \
-                 exec — Paygress is the spawn/billing fabric, not the exec channel."
+                 Lifecycle: `list_providers` (discover) → `spawn_workload` (single) or \
+                 `batch_spawn` (N-shard fan-out) → `workload_status` (monitor) → \
+                 `topup_workload` (extend before expiry). The agent connects to the \
+                 returned host:ssh_port itself to actually run code — Paygress is the \
+                 spawn/billing/lifecycle fabric, not the exec channel."
                     .to_string(),
             ),
             capabilities: ServerCapabilities::builder().enable_tools().build(),
@@ -446,11 +572,13 @@ mod tests {
         let server = PaygressMcpServer::new(McpArgs::default());
         let info = server.get_info();
         assert!(info.capabilities.tools.is_some());
-        assert!(info
-            .instructions
-            .as_deref()
-            .unwrap_or("")
-            .contains("Paygress"));
+        let inst = info.instructions.as_deref().unwrap_or("");
+        assert!(inst.contains("Paygress"));
+        // Pin the lifecycle hint so future edits don't drop the
+        // workload_status / topup_workload mentions — agents rely on
+        // these to know when to call them.
+        assert!(inst.contains("workload_status"));
+        assert!(inst.contains("topup_workload"));
     }
 
     #[test]
@@ -479,6 +607,29 @@ mod tests {
         assert_eq!(v.template, "agent-sandbox");
         assert_eq!(v.tier, "basic");
         assert_eq!(v.tokens.as_ref().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn status_params_defaults_round_trip() {
+        let v = serde_json::from_value::<StatusParams>(serde_json::json!({
+            "provider": "npub1abc",
+            "pod_id": "container-7",
+        }))
+        .unwrap();
+        assert_eq!(v.timeout_secs, 30);
+        assert_eq!(v.pod_id, "container-7");
+    }
+
+    #[test]
+    fn topup_params_defaults_round_trip() {
+        let v = serde_json::from_value::<TopupParams>(serde_json::json!({
+            "provider": "npub1abc",
+            "pod_id": "container-7",
+            "token": "tok",
+        }))
+        .unwrap();
+        assert_eq!(v.timeout_secs, 120);
+        assert_eq!(v.token, "tok");
     }
 
     #[test]

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -85,16 +85,62 @@ async fn execute_http_status(server: &str, args: StatusArgs, verbose: bool) -> R
     Ok(())
 }
 
+/// Typed outcome of a Nostr status round-trip. Same dual-shape
+/// pattern as `NostrSpawnOutcome`: lets the pretty-print path and
+/// the MCP server share one transport.
+#[derive(Debug, Clone)]
+pub enum NostrStatusOutcome {
+    Success(paygress::nostr::StatusResponseContent),
+    /// Provider responded but the body wasn't a valid status response
+    /// (could be a future-shape forward-compat surprise).
+    UnparseableResponse(String),
+    /// Provider didn't respond within the timeout window.
+    Timeout,
+}
+
+/// Dispatch a single Nostr status request and wait for the provider's
+/// reply. No I/O on stdout — pure round-trip + structured outcome.
+pub async fn nostr_status_round_trip(
+    pod_id: &str,
+    provider_npub: &str,
+    relays: Vec<String>,
+    nostr_key: String,
+    timeout_secs: u64,
+) -> Result<NostrStatusOutcome> {
+    use paygress::discovery::DiscoveryClient;
+    use paygress::nostr::{StatusRequestContent, StatusResponseContent};
+
+    let client = DiscoveryClient::new_with_key(relays, nostr_key).await?;
+
+    let request = StatusRequestContent {
+        pod_id: pod_id.to_string(),
+    };
+    let request_json = serde_json::to_string(&request)?;
+
+    client
+        .nostr()
+        .send_encrypted_private_message(provider_npub, request_json, "nip04")
+        .await?;
+
+    match client
+        .nostr()
+        .wait_for_decrypted_message(provider_npub, timeout_secs)
+        .await
+    {
+        Ok(response) => match serde_json::from_str::<StatusResponseContent>(&response.content) {
+            Ok(s) => Ok(NostrStatusOutcome::Success(s)),
+            Err(_) => Ok(NostrStatusOutcome::UnparseableResponse(response.content)),
+        },
+        Err(_) => Ok(NostrStatusOutcome::Timeout),
+    }
+}
+
 async fn execute_nostr_status(
     pod_id: String,
     provider_npub: String,
     relays_opt: Option<String>,
     verbose: bool,
 ) -> Result<()> {
-    use paygress::nostr::{
-        NostrRelaySubscriber, RelayConfig, StatusRequestContent, StatusResponseContent,
-    };
-
     if verbose {
         println!("{} Checking workload status via Nostr...", "->".blue());
         println!("  Provider: {}", provider_npub);
@@ -112,34 +158,12 @@ async fn execute_nostr_status(
 
     let nostr_key = get_or_create_identity(None)?;
     let relays = parse_relays(relays_opt);
-    let relay_config = RelayConfig {
-        relays,
-        private_key: Some(nostr_key),
-    };
 
-    let client = NostrRelaySubscriber::new(relay_config).await?;
+    let outcome = nostr_status_round_trip(&pod_id, &provider_npub, relays, nostr_key, 30).await?;
+    spinner.finish_and_clear();
 
-    client
-        .subscribe_to_pod_events(|_| Box::pin(async { Ok(()) }))
-        .await?;
-
-    let request = StatusRequestContent {
-        pod_id: pod_id.clone(),
-    };
-    let content = serde_json::to_string(&request)?;
-
-    client
-        .send_encrypted_private_message(&provider_npub, content, "nip17")
-        .await?;
-
-    spinner.set_message("Waiting for provider response...");
-
-    match client.wait_for_decrypted_message(&provider_npub, 30).await {
-        Ok(response_event) => {
-            spinner.finish_and_clear();
-
-            let status_resp: StatusResponseContent = serde_json::from_str(&response_event.content)?;
-
+    match outcome {
+        NostrStatusOutcome::Success(status_resp) => {
             display_status(
                 &status_resp.pod_id,
                 &status_resp.status,
@@ -150,11 +174,15 @@ async fn execute_nostr_status(
                 Some(status_resp.time_remaining_seconds),
             );
         }
-        Err(e) => {
-            spinner.finish_and_clear();
+        NostrStatusOutcome::UnparseableResponse(body) => {
             return Err(anyhow::anyhow!(
-                "Timed out waiting for status from provider: {}",
-                e
+                "Provider returned an unrecognized status response (forward-compat schema?): {}",
+                body
+            ));
+        }
+        NostrStatusOutcome::Timeout => {
+            return Err(anyhow::anyhow!(
+                "Timed out waiting for status from provider"
             ));
         }
     }

--- a/src/cli/commands/topup.rs
+++ b/src/cli/commands/topup.rs
@@ -149,6 +149,71 @@ async fn execute_http_topup(
     Ok(())
 }
 
+/// Typed outcome of a Nostr topup round-trip. Same dual-shape pattern
+/// as `NostrSpawnOutcome` — lets the pretty-print path and the MCP
+/// server share one transport.
+#[derive(Debug, Clone)]
+pub enum NostrTopupOutcome {
+    Success(paygress::nostr::TopUpResponseContent),
+    /// Provider rejected the topup (insufficient payment, lease
+    /// expired, not the owner, race-lost, etc.). Error type strings
+    /// are stable — callers can match.
+    ProviderError(paygress::nostr::ErrorResponseContent),
+    /// Provider responded but the body wasn't either schema.
+    UnknownResponse(String),
+    /// Provider didn't respond within the timeout window. The token
+    /// MAY have been spent — caller should `status` to check.
+    Timeout,
+}
+
+/// Dispatch a single Nostr topup request and wait for the provider's
+/// reply. No I/O on stdout — pure round-trip + structured outcome.
+pub async fn nostr_topup_round_trip(
+    pod_id: &str,
+    token: &str,
+    provider_npub: &str,
+    relays: Vec<String>,
+    nostr_key: String,
+    timeout_secs: u64,
+) -> Result<NostrTopupOutcome> {
+    use paygress::nostr::{EncryptedTopUpPodRequest, ErrorResponseContent, TopUpResponseContent};
+
+    let client = DiscoveryClient::new_with_key(relays, nostr_key).await?;
+
+    let request = EncryptedTopUpPodRequest {
+        pod_npub: pod_id.to_string(),
+        cashu_token: token.to_string(),
+    };
+    let request_json = serde_json::to_string(&request)?;
+
+    client
+        .nostr()
+        .send_encrypted_private_message(provider_npub, request_json, "nip04")
+        .await?;
+
+    match client
+        .nostr()
+        .wait_for_decrypted_message(provider_npub, timeout_secs)
+        .await
+    {
+        Ok(response) => {
+            // Provider reply order: try TopUpResponseContent first
+            // (the success path) then ErrorResponseContent. Both have
+            // distinct shapes so the wrong-type parse fails cleanly.
+            if let Ok(s) = serde_json::from_str::<TopUpResponseContent>(&response.content) {
+                Ok(NostrTopupOutcome::Success(s))
+            } else if let Ok(err) =
+                serde_json::from_str::<ErrorResponseContent>(&response.content)
+            {
+                Ok(NostrTopupOutcome::ProviderError(err))
+            } else {
+                Ok(NostrTopupOutcome::UnknownResponse(response.content))
+            }
+        }
+        Err(_) => Ok(NostrTopupOutcome::Timeout),
+    }
+}
+
 async fn execute_nostr_topup(
     provider_npub: String,
     args: TopupArgs,
@@ -162,56 +227,49 @@ async fn execute_nostr_topup(
     let relays = parse_relays(args.relays);
     let nostr_key = get_or_create_identity(args.nostr_key)?;
 
-    let client = DiscoveryClient::new_with_key(relays, nostr_key).await?;
-
     println!("  Pod ID:   {}", args.pod_id.cyan());
     println!("  Provider: {}", provider_npub);
     println!();
-
-    let request = paygress::nostr::EncryptedTopUpPodRequest {
-        pod_npub: args.pod_id.clone(),
-        cashu_token: token,
-    };
-
     print!("  Sending topup request... ");
-
-    let request_json = serde_json::to_string(&request)?;
-    client
-        .nostr()
-        .send_encrypted_private_message(&provider_npub, request_json, "nip04")
-        .await?;
-
     println!("{}", "SENT".green());
     println!();
     println!("  Waiting for provider response (timeout: 60s)...");
 
-    match client
-        .nostr()
-        .wait_for_decrypted_message(&provider_npub, 60)
-        .await
-    {
-        Ok(response) => {
-            println!();
-            if let Ok(resp) = serde_json::from_str::<serde_json::Value>(&response.content) {
-                if resp.get("error").is_some() {
-                    println!("{}", "Topup failed".red().bold());
-                    println!("  {}", resp["error"].as_str().unwrap_or("Unknown error"));
-                } else {
-                    println!("{}", "Topup successful!".green().bold());
-                    if let Some(expires) = resp.get("expires_at") {
-                        println!("  {} {}", "New Expiry:".bold(), expires);
-                    }
-                    if let Some(added) = resp.get("added_seconds") {
-                        println!("  {} +{}s", "Added:".bold(), added);
-                    }
-                }
-            } else {
-                println!("Provider response: {}", response.content);
+    let outcome =
+        nostr_topup_round_trip(&args.pod_id, &token, &provider_npub, relays, nostr_key, 60).await?;
+    println!();
+
+    match outcome {
+        NostrTopupOutcome::Success(resp) => {
+            println!("{}", "Topup successful!".green().bold());
+            println!("  {} {}", "New Expiry:".bold(), resp.new_expires_at);
+            println!(
+                "  {} +{}s",
+                "Added:".bold(),
+                resp.extended_duration_seconds
+            );
+            if !resp.message.is_empty() {
+                println!("  {} {}", "Message:".bold(), resp.message);
             }
         }
-        Err(e) => {
-            println!();
-            println!("  {} {}", "Warning:".yellow(), e.to_string().yellow());
+        NostrTopupOutcome::ProviderError(err) => {
+            println!("{}", "Topup failed".red().bold());
+            println!("  Type:    {}", err.error_type);
+            println!("  Message: {}", err.message);
+            if let Some(d) = err.details {
+                println!("  Details: {}", d);
+            }
+        }
+        NostrTopupOutcome::UnknownResponse(body) => {
+            println!("{}", "Unknown topup response".yellow().bold());
+            println!("Body: {}", body);
+        }
+        NostrTopupOutcome::Timeout => {
+            println!(
+                "  {} {}",
+                "Warning:".yellow(),
+                "Provider didn't respond in time.".yellow()
+            );
             println!("The topup request was sent but the provider didn't respond in time.");
             println!(
                 "Check status with: paygress-cli status --pod-id {} --provider {}",

--- a/src/cli/commands/topup.rs
+++ b/src/cli/commands/topup.rs
@@ -149,6 +149,70 @@ async fn execute_http_topup(
     Ok(())
 }
 
+/// Typed outcome of a Nostr topup round-trip. Same dual-shape pattern
+/// as `NostrSpawnOutcome` — lets the pretty-print path and the MCP
+/// server share one transport.
+#[derive(Debug, Clone)]
+pub enum NostrTopupOutcome {
+    Success(paygress::nostr::TopUpResponseContent),
+    /// Provider rejected the topup (insufficient payment, lease
+    /// expired, not the owner, race-lost, etc.). Error type strings
+    /// are stable — callers can match.
+    ProviderError(paygress::nostr::ErrorResponseContent),
+    /// Provider responded but the body wasn't either schema.
+    UnknownResponse(String),
+    /// Provider didn't respond within the timeout window. The token
+    /// MAY have been spent — caller should `status` to check.
+    Timeout,
+}
+
+/// Dispatch a single Nostr topup request and wait for the provider's
+/// reply. No I/O on stdout — pure round-trip + structured outcome.
+pub async fn nostr_topup_round_trip(
+    pod_id: &str,
+    token: &str,
+    provider_npub: &str,
+    relays: Vec<String>,
+    nostr_key: String,
+    timeout_secs: u64,
+) -> Result<NostrTopupOutcome> {
+    use paygress::nostr::{EncryptedTopUpPodRequest, ErrorResponseContent, TopUpResponseContent};
+
+    let client = DiscoveryClient::new_with_key(relays, nostr_key).await?;
+
+    let request = EncryptedTopUpPodRequest {
+        pod_npub: pod_id.to_string(),
+        cashu_token: token.to_string(),
+    };
+    let request_json = serde_json::to_string(&request)?;
+
+    client
+        .nostr()
+        .send_encrypted_private_message(provider_npub, request_json, "nip04")
+        .await?;
+
+    match client
+        .nostr()
+        .wait_for_decrypted_message(provider_npub, timeout_secs)
+        .await
+    {
+        Ok(response) => {
+            // Provider reply order: try TopUpResponseContent first
+            // (the success path) then ErrorResponseContent. Both have
+            // distinct shapes so the wrong-type parse fails cleanly.
+            if let Ok(s) = serde_json::from_str::<TopUpResponseContent>(&response.content) {
+                Ok(NostrTopupOutcome::Success(s))
+            } else if let Ok(err) = serde_json::from_str::<ErrorResponseContent>(&response.content)
+            {
+                Ok(NostrTopupOutcome::ProviderError(err))
+            } else {
+                Ok(NostrTopupOutcome::UnknownResponse(response.content))
+            }
+        }
+        Err(_) => Ok(NostrTopupOutcome::Timeout),
+    }
+}
+
 async fn execute_nostr_topup(
     provider_npub: String,
     args: TopupArgs,
@@ -162,56 +226,45 @@ async fn execute_nostr_topup(
     let relays = parse_relays(args.relays);
     let nostr_key = get_or_create_identity(args.nostr_key)?;
 
-    let client = DiscoveryClient::new_with_key(relays, nostr_key).await?;
-
     println!("  Pod ID:   {}", args.pod_id.cyan());
     println!("  Provider: {}", provider_npub);
     println!();
-
-    let request = paygress::nostr::EncryptedTopUpPodRequest {
-        pod_npub: args.pod_id.clone(),
-        cashu_token: token,
-    };
-
     print!("  Sending topup request... ");
-
-    let request_json = serde_json::to_string(&request)?;
-    client
-        .nostr()
-        .send_encrypted_private_message(&provider_npub, request_json, "nip04")
-        .await?;
-
     println!("{}", "SENT".green());
     println!();
     println!("  Waiting for provider response (timeout: 60s)...");
 
-    match client
-        .nostr()
-        .wait_for_decrypted_message(&provider_npub, 60)
-        .await
-    {
-        Ok(response) => {
-            println!();
-            if let Ok(resp) = serde_json::from_str::<serde_json::Value>(&response.content) {
-                if resp.get("error").is_some() {
-                    println!("{}", "Topup failed".red().bold());
-                    println!("  {}", resp["error"].as_str().unwrap_or("Unknown error"));
-                } else {
-                    println!("{}", "Topup successful!".green().bold());
-                    if let Some(expires) = resp.get("expires_at") {
-                        println!("  {} {}", "New Expiry:".bold(), expires);
-                    }
-                    if let Some(added) = resp.get("added_seconds") {
-                        println!("  {} +{}s", "Added:".bold(), added);
-                    }
-                }
-            } else {
-                println!("Provider response: {}", response.content);
+    let outcome =
+        nostr_topup_round_trip(&args.pod_id, &token, &provider_npub, relays, nostr_key, 60).await?;
+    println!();
+
+    match outcome {
+        NostrTopupOutcome::Success(resp) => {
+            println!("{}", "Topup successful!".green().bold());
+            println!("  {} {}", "New Expiry:".bold(), resp.new_expires_at);
+            println!("  {} +{}s", "Added:".bold(), resp.extended_duration_seconds);
+            if !resp.message.is_empty() {
+                println!("  {} {}", "Message:".bold(), resp.message);
             }
         }
-        Err(e) => {
-            println!();
-            println!("  {} {}", "Warning:".yellow(), e.to_string().yellow());
+        NostrTopupOutcome::ProviderError(err) => {
+            println!("{}", "Topup failed".red().bold());
+            println!("  Type:    {}", err.error_type);
+            println!("  Message: {}", err.message);
+            if let Some(d) = err.details {
+                println!("  Details: {}", d);
+            }
+        }
+        NostrTopupOutcome::UnknownResponse(body) => {
+            println!("{}", "Unknown topup response".yellow().bold());
+            println!("Body: {}", body);
+        }
+        NostrTopupOutcome::Timeout => {
+            println!(
+                "  {} {}",
+                "Warning:".yellow(),
+                "Provider didn't respond in time.".yellow()
+            );
             println!("The topup request was sent but the provider didn't respond in time.");
             println!(
                 "Check status with: paygress-cli status --pod-id {} --provider {}",


### PR DESCRIPTION
## Summary

Completes the agent-facing lifecycle on the MCP server:

```
discover (list_providers)
  → spawn (spawn_workload | batch_spawn)
  → monitor (workload_status)              ← NEW
  → extend (topup_workload)                ← NEW
```

> Stacks on top of #38. Base branch is \`feat/mcp-server\`.

An LLM driving Paygress through MCP can now run the full lease lifecycle without going out-of-band. Typical agent pattern:

```
1. batch_spawn { split_token: "...", shards: 10 }
2. (work happens over SSH/HTTP off-protocol)
3. workload_status { pod_id: "container-1042" }   // before expiry
4. topup_workload { token: "..." }                // if more time needed
```

## Refactor

Mirrors the `nostr_spawn_round_trip` extraction in #38:

- **`status.rs`**: pub `nostr_status_round_trip()` returning typed `NostrStatusOutcome { Success, UnparseableResponse, Timeout }`
- **`topup.rs`**: pub `nostr_topup_round_trip()` returning typed `NostrTopupOutcome { Success, ProviderError, UnknownResponse, Timeout }`. Stable `error_type` strings preserved (`lease_expired`, `not_owner`, `insufficient_payment`, `race_lost`, etc.) so callers can match programmatically.
- Interactive CLI commands now share these helpers — same transport whether invoked by hand or by an MCP client.

Side note: the existing `execute_nostr_status` had a likely-broken `subscribe_to_pod_events` call block that would have hung the future indefinitely. Removed in the refactor — `DiscoveryClient::wait_for_decrypted_message` already self-subscribes.

## Tests

- 2 new params-default round-trip tests (`StatusParams`, `TopupParams`)
- `server_advertises_tool_capability` extended to pin that the server's `instructions` mention `workload_status` + `topup_workload` so future edits don't silently drop them — agents rely on these hints to know when to call them
- Full suite: **118 green**

## Smoke-tested

Manually fed stdin: \`tools/list\` returns 5 tools (\`list_providers\`, \`spawn_workload\`, \`batch_spawn\`, \`workload_status\`, \`topup_workload\`) all with full JSON schemas.

## Test plan

- [x] \`cargo test --no-default-features\` (118/118)
- [x] Manual stdio smoke: tools/list shows all 5 tools
- [ ] Plug into Claude Desktop and verify the new tools appear in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)