### PR TITLE
feat(agent-sandbox): bake HTTP exec server + add run_command MCP tool

### DIFF
--- a/.github/workflows/agent-sandbox-image.yml
+++ b/.github/workflows/agent-sandbox-image.yml
@@ -1,0 +1,54 @@
+name: agent-sandbox image
+
+on:
+  # Manual trigger so maintainers can rebuild without a tag bump.
+  workflow_dispatch:
+  # Tag-driven publish. Tag pattern is intentionally distinct from
+  # paygress-cli release tags so cli releases don't churn the image.
+  push:
+    tags:
+      - 'agent-sandbox-v*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # Lowercase image name; ghcr is case-sensitive on owner.
+          images: ghcr.io/${{ github.repository_owner }}/paygress-agent-sandbox
+          tags: |
+            type=match,pattern=agent-sandbox-(v.+),group=1
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./images/agent-sandbox
+          # Multi-arch so providers running on ARM64 hosts (Hetzner
+          # AX-arm, Oracle Ampere, Apple Silicon test boxes) pull a
+          # native image instead of qemu-emulating amd64.
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/images/agent-sandbox/Dockerfile
+++ b/images/agent-sandbox/Dockerfile
@@ -1,0 +1,40 @@
+# paygress/agent-sandbox image — generic compute sandbox for AI agents,
+# CI runners, and map-reduce shards.
+#
+# Layer choices:
+# - nikolaik/python-nodejs:python3.12-nodejs20 base. Already had this
+#   reference in the agent-sandbox template as the minimum-viable
+#   "Python + Node + git" surface; we layer on top instead of starting
+#   from a leaner base because the cross-compatibility (apt, pip, npm
+#   all available) outweighs ~500MB image size for the agent use case.
+# - server.py is a self-contained stdlib HTTP server; no pip install
+#   step in the build.
+# - ENTRYPOINT runs the server. WORKSPACE / EXEC_USER / EXEC_PASS are
+#   read from env at runtime — the provider injects them at spawn
+#   time from the consumer's spawn request (ssh creds reused).
+#
+# Build (locally):
+#   docker build -t ghcr.io/dhananjaypurohit/paygress-agent-sandbox:0.1.0 \
+#                images/agent-sandbox
+#
+# CI publishes on tags `agent-sandbox-v*` via
+# .github/workflows/agent-sandbox-image.yml.
+
+FROM nikolaik/python-nodejs:python3.12-nodejs20
+
+# /workspace is the contract surface — agents drop scripts here, the
+# exec server defaults its CWD here, and the data_path on the
+# template config points at the same path so a per-vmid Docker volume
+# persists across container restarts on the same provider.
+RUN mkdir -p /workspace && chmod 0777 /workspace
+
+COPY server.py /usr/local/bin/paygress-exec
+RUN chmod +x /usr/local/bin/paygress-exec
+
+ENV WORKSPACE=/workspace \
+    PYTHONUNBUFFERED=1 \
+    NODE_ENV=production
+
+EXPOSE 8080
+
+ENTRYPOINT ["python3", "/usr/local/bin/paygress-exec"]

--- a/images/agent-sandbox/server.py
+++ b/images/agent-sandbox/server.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Paygress agent-sandbox exec server.
+
+Tiny HTTP server that lets a client (paygress-cli exec, the MCP
+run_command tool, or any HTTP-capable agent) execute shell commands
+inside this container and stream back the result.
+
+Auth: HTTP Basic against EXEC_USER / EXEC_PASS env vars set by the
+provider at container-start time. The provider knows these because
+the consumer's spawn request ships them as ssh_username/ssh_password
+(reused as exec credentials so users don't have a second secret to
+manage).
+
+Wire format:
+    POST /exec   {command: str, timeout_secs?: int, working_dir?: str}
+                 -> {stdout, stderr, exit_code, duration_ms, timed_out}
+    GET  /health -> 200 OK ({"status": "ok", "workspace": "/workspace"})
+
+Stdlib-only (http.server + base64 + subprocess + json) so it works
+inside the nikolaik/python-nodejs base image with zero pip installs.
+"""
+
+import base64
+import json
+import os
+import subprocess
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+LISTEN_HOST = "0.0.0.0"
+LISTEN_PORT = 8080
+WORKSPACE = os.environ.get("WORKSPACE", "/workspace")
+EXEC_USER = os.environ.get("EXEC_USER", "")
+EXEC_PASS = os.environ.get("EXEC_PASS", "")
+DEFAULT_TIMEOUT_SECS = 60
+MAX_TIMEOUT_SECS = 1800  # 30 min hard cap so a runaway script can't DoS the lease
+
+
+def expected_authorization() -> str:
+    creds = f"{EXEC_USER}:{EXEC_PASS}".encode("utf-8")
+    return "Basic " + base64.b64encode(creds).decode("ascii")
+
+
+class ExecHandler(BaseHTTPRequestHandler):
+    # Don't dump every request to stderr; the provider already
+    # captures container logs and the auth header would be noisy.
+    def log_message(self, format, *args):
+        return
+
+    def _json_response(self, status: int, body: dict) -> None:
+        payload = json.dumps(body).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _check_auth(self) -> bool:
+        if not EXEC_USER or not EXEC_PASS:
+            # Refuse to start serving auth-protected endpoints if creds
+            # weren't injected. Surfaces the misconfiguration loudly
+            # rather than silently allowing anonymous exec.
+            self._json_response(503, {"error": "exec credentials not configured"})
+            return False
+        got = self.headers.get("Authorization", "")
+        if got != expected_authorization():
+            self.send_response(401)
+            self.send_header("WWW-Authenticate", 'Basic realm="paygress-exec"')
+            self.end_headers()
+            return False
+        return True
+
+    def do_GET(self):
+        if self.path == "/health":
+            # Health check stays unauthenticated so the provider can
+            # liveness-probe the container without juggling creds.
+            self._json_response(
+                200,
+                {"status": "ok", "workspace": WORKSPACE, "service": "paygress-exec"},
+            )
+            return
+        self._json_response(404, {"error": "not found"})
+
+    def do_POST(self):
+        if self.path != "/exec":
+            self._json_response(404, {"error": "not found"})
+            return
+        if not self._check_auth():
+            return
+
+        length = int(self.headers.get("Content-Length", "0"))
+        try:
+            body = json.loads(self.rfile.read(length).decode("utf-8"))
+        except Exception as e:
+            self._json_response(400, {"error": f"invalid json body: {e}"})
+            return
+
+        command = body.get("command")
+        if not isinstance(command, str) or not command.strip():
+            self._json_response(400, {"error": "`command` (non-empty string) is required"})
+            return
+        timeout_secs = int(body.get("timeout_secs") or DEFAULT_TIMEOUT_SECS)
+        if timeout_secs <= 0 or timeout_secs > MAX_TIMEOUT_SECS:
+            self._json_response(
+                400,
+                {
+                    "error": f"timeout_secs must be in 1..={MAX_TIMEOUT_SECS}",
+                },
+            )
+            return
+        working_dir = body.get("working_dir") or WORKSPACE
+
+        # Execute via bash -lc so the user can write idiomatic shell
+        # (`cd && python script.py | tee out.log`). A wrapper shell is
+        # the standard agent-sandbox shape — the alternative (parsing
+        # argv into argc) blocks pipes/redirects and is hostile to
+        # the LLM's natural output style.
+        start = time.monotonic()
+        timed_out = False
+        try:
+            result = subprocess.run(
+                ["bash", "-lc", command],
+                cwd=working_dir,
+                capture_output=True,
+                timeout=timeout_secs,
+            )
+            stdout = result.stdout.decode("utf-8", errors="replace")
+            stderr = result.stderr.decode("utf-8", errors="replace")
+            exit_code = result.returncode
+        except subprocess.TimeoutExpired as e:
+            timed_out = True
+            stdout = (e.stdout or b"").decode("utf-8", errors="replace")
+            stderr = (e.stderr or b"").decode("utf-8", errors="replace")
+            exit_code = -1
+        duration_ms = int((time.monotonic() - start) * 1000)
+
+        self._json_response(
+            200,
+            {
+                "stdout": stdout,
+                "stderr": stderr,
+                "exit_code": exit_code,
+                "duration_ms": duration_ms,
+                "timed_out": timed_out,
+            },
+        )
+
+
+def main():
+    if not EXEC_USER or not EXEC_PASS:
+        print(
+            "warning: EXEC_USER/EXEC_PASS not set — /exec will return 503 until the provider injects credentials",
+            file=sys.stderr,
+        )
+    os.makedirs(WORKSPACE, exist_ok=True)
+    server = ThreadingHTTPServer((LISTEN_HOST, LISTEN_PORT), ExecHandler)
+    print(f"paygress-exec listening on {LISTEN_HOST}:{LISTEN_PORT} (workspace: {WORKSPACE})", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cli/commands/exec.rs
+++ b/src/cli/commands/exec.rs
@@ -1,0 +1,111 @@
+// `paygress-cli exec` — run a shell command inside a spawned
+// agent-sandbox workload via its baked-in HTTP exec server.
+//
+// Used both as a standalone CLI convenience (interactive shell loop,
+// CI scripts, batch fan-out) and as the underlying transport for the
+// MCP `run_command` tool. Both call into `cli::exec_client::call_exec`
+// so behavior stays identical.
+//
+// The host / port / user / pass values come from a prior
+// `paygress-cli spawn` (or `batch`) — see the `--from-manifest` shape
+// in the batch coordinator's docs for the natural pipeline.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use clap::Args;
+use colored::Colorize;
+
+use crate::exec_client;
+
+#[derive(Args)]
+pub struct ExecArgs {
+    /// Host the agent-sandbox is published on. Either a bare host
+    /// (1.2.3.4 / example.com) or a full URL (http://...). Comes from
+    /// AccessDetails.host_address on the spawn response.
+    #[arg(long)]
+    pub host: String,
+
+    /// Port the exec server is reachable on. For agent-sandbox
+    /// templates this is the host port mapped to container 8080
+    /// (printed as `sandbox-exec` in the spawn response's template
+    /// ports list).
+    #[arg(long)]
+    pub port: u16,
+
+    /// HTTP Basic auth username. Defaults to `root` (matching what
+    /// the provider sets via the EXEC_USER env var on the container).
+    #[arg(long, default_value = "root")]
+    pub user: String,
+
+    /// HTTP Basic auth password. Use the password the spawn response
+    /// printed in the connection instructions.
+    #[arg(long)]
+    pub pass: String,
+
+    /// Shell command to run. Interpreted by `bash -lc` inside the
+    /// container, so pipes / redirects / `cd ... && ...` all work.
+    #[arg(short, long)]
+    pub command: String,
+
+    /// Server-side command timeout (seconds). Server caps this at
+    /// 1800s. Client transport timeout is set 5s above this so the
+    /// server can return a structured `timed_out: true` response
+    /// before our HTTP call gives up.
+    #[arg(long, default_value_t = 60)]
+    pub timeout_secs: u64,
+
+    /// Override the working directory. Defaults server-side to
+    /// `/workspace`.
+    #[arg(long)]
+    pub working_dir: Option<String>,
+
+    /// Print structured JSON instead of human-readable
+    /// stdout/stderr/exit. Useful for scripts.
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub async fn execute(args: ExecArgs, _verbose: bool) -> Result<()> {
+    let total_timeout = Duration::from_secs(args.timeout_secs.saturating_add(5));
+    let resp = exec_client::call_exec(
+        &args.host,
+        args.port,
+        &args.user,
+        &args.pass,
+        &args.command,
+        Some(args.timeout_secs),
+        args.working_dir.as_deref(),
+        total_timeout,
+    )
+    .await?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&resp)?);
+    } else {
+        if !resp.stdout.is_empty() {
+            print!("{}", resp.stdout);
+        }
+        if !resp.stderr.is_empty() {
+            eprint!("{}", resp.stderr);
+        }
+        if resp.timed_out {
+            eprintln!(
+                "{} command timed out after {}s",
+                "[timeout]".yellow(),
+                args.timeout_secs
+            );
+        }
+        eprintln!(
+            "{} exit={} duration={}ms",
+            "[done]".dimmed(),
+            resp.exit_code,
+            resp.duration_ms
+        );
+    }
+
+    if resp.exit_code != 0 || resp.timed_out {
+        std::process::exit(if resp.timed_out { 124 } else { resp.exit_code });
+    }
+    Ok(())
+}

--- a/src/cli/commands/mcp.rs
+++ b/src/cli/commands/mcp.rs
@@ -37,6 +37,7 @@ use super::identity::{get_or_create_identity, parse_relays};
 use super::spawn::{nostr_spawn_round_trip, NostrSpawnOutcome};
 use super::status::{nostr_status_round_trip, NostrStatusOutcome};
 use super::topup::{nostr_topup_round_trip, NostrTopupOutcome};
+use crate::exec_client;
 use paygress::discovery::DiscoveryClient;
 use paygress::nostr::ProviderFilter;
 
@@ -190,6 +191,41 @@ pub struct TopupParams {
     /// Per-call timeout in seconds.
     #[serde(default = "default_timeout_secs")]
     pub timeout_secs: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RunCommandParams {
+    /// Host the agent-sandbox is published on. Comes from the
+    /// `host` field of a `spawn_workload` / `batch_spawn` response.
+    pub host: String,
+    /// Port the exec server is reachable on. For the `agent-sandbox`
+    /// template this is the host port mapped to container 8080
+    /// (label `sandbox-exec` in the template ports list).
+    pub port: u16,
+    /// HTTP Basic auth username. The provider sets this to "root"
+    /// inside the container; rarely overridden.
+    #[serde(default = "default_exec_user")]
+    pub user: String,
+    /// HTTP Basic auth password. Must match the password the spawn
+    /// response printed (the provider injects it as EXEC_PASS in the
+    /// container's env).
+    pub pass: String,
+    /// Shell command to run. Interpreted by `bash -lc` inside the
+    /// container, so pipes / redirects work naturally.
+    pub command: String,
+    /// Server-side command timeout (seconds). Capped at 1800.
+    #[serde(default = "default_exec_timeout_secs")]
+    pub timeout_secs: u64,
+    /// Override the working directory. Defaults to /workspace.
+    #[serde(default)]
+    pub working_dir: Option<String>,
+}
+
+fn default_exec_user() -> String {
+    "root".to_string()
+}
+fn default_exec_timeout_secs() -> u64 {
+    60
 }
 
 #[tool_router]
@@ -543,6 +579,45 @@ impl PaygressMcpServer {
             serde_json::to_string_pretty(&body).unwrap_or_else(|_| "{}".to_string()),
         )]))
     }
+
+    #[tool(
+        description = "Run a shell command inside an agent-sandbox workload via its baked-in HTTP exec server. Pass the host and port from the spawn response (port label `sandbox-exec`), plus the SSH password (the provider reuses it as EXEC_PASS). Returns stdout, stderr, exit_code, duration_ms, timed_out. Use this immediately after `spawn_workload` to actually run code inside the paid sandbox — Paygress is the spawn fabric, this is the exec channel."
+    )]
+    async fn run_command(
+        &self,
+        Parameters(params): Parameters<RunCommandParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let total_timeout = std::time::Duration::from_secs(params.timeout_secs.saturating_add(5));
+        let outcome = exec_client::call_exec(
+            &params.host,
+            params.port,
+            &params.user,
+            &params.pass,
+            &params.command,
+            Some(params.timeout_secs),
+            params.working_dir.as_deref(),
+            total_timeout,
+        )
+        .await;
+
+        let body = match outcome {
+            Ok(resp) => serde_json::json!({
+                "status": "ok",
+                "stdout": resp.stdout,
+                "stderr": resp.stderr,
+                "exit_code": resp.exit_code,
+                "duration_ms": resp.duration_ms,
+                "timed_out": resp.timed_out,
+            }),
+            Err(e) => serde_json::json!({
+                "status": "transport_error",
+                "message": e.to_string(),
+            }),
+        };
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&body).unwrap_or_else(|_| "{}".to_string()),
+        )]))
+    }
 }
 
 #[tool_handler]
@@ -551,11 +626,13 @@ impl ServerHandler for PaygressMcpServer {
         ServerInfo {
             instructions: Some(
                 "Paygress: pay-per-use compute marketplace using Cashu ecash and Nostr. \
-                 Lifecycle: `list_providers` (discover) → `spawn_workload` (single) or \
-                 `batch_spawn` (N-shard fan-out) → `workload_status` (monitor) → \
-                 `topup_workload` (extend before expiry). The agent connects to the \
-                 returned host:ssh_port itself to actually run code — Paygress is the \
-                 spawn/billing/lifecycle fabric, not the exec channel."
+                 Full lifecycle: `list_providers` (discover) → `spawn_workload` / \
+                 `batch_spawn` (pay + provision) → `run_command` (exec inside the \
+                 sandbox via its baked-in HTTP server) → `workload_status` (monitor) \
+                 → `topup_workload` (extend before expiry). For the canonical agent \
+                 flow: spawn an `agent-sandbox` template, then call `run_command` \
+                 with the returned host + sandbox-exec port + ssh_pass — that's the \
+                 paid box's stdout in your hand."
                     .to_string(),
             ),
             capabilities: ServerCapabilities::builder().enable_tools().build(),
@@ -587,10 +664,26 @@ mod tests {
         let inst = info.instructions.as_deref().unwrap_or("");
         assert!(inst.contains("Paygress"));
         // Pin the lifecycle hint so future edits don't drop the
-        // workload_status / topup_workload mentions — agents rely on
-        // these to know when to call them.
+        // workload_status / topup_workload / run_command mentions —
+        // agents rely on these to know when to call them.
         assert!(inst.contains("workload_status"));
         assert!(inst.contains("topup_workload"));
+        assert!(inst.contains("run_command"));
+    }
+
+    #[test]
+    fn run_command_params_defaults_round_trip() {
+        let v = serde_json::from_value::<RunCommandParams>(serde_json::json!({
+            "host": "1.2.3.4",
+            "port": 30043,
+            "pass": "hunter2",
+            "command": "ls /workspace",
+        }))
+        .unwrap();
+        assert_eq!(v.user, "root");
+        assert_eq!(v.timeout_secs, 60);
+        assert!(v.working_dir.is_none());
+        assert_eq!(v.command, "ls /workspace");
     }
 
     #[test]

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -3,6 +3,7 @@
 pub mod batch;
 pub mod bootstrap;
 pub mod deploy;
+pub mod exec;
 pub mod identity;
 pub mod list;
 pub mod mcp;

--- a/src/cli/exec_client.rs
+++ b/src/cli/exec_client.rs
@@ -1,0 +1,203 @@
+// Typed HTTP client for the agent-sandbox exec server
+// (`images/agent-sandbox/server.py`).
+//
+// Used by:
+//   - `paygress-cli exec`              (interactive shell convenience)
+//   - `paygress-cli mcp` `run_command` (agent-driven exec)
+//
+// Wire format mirrors the server's:
+//   POST http://<host>:<port>/exec
+//   Authorization: Basic <base64(user:pass)>
+//   Body: {"command": "<bash command>", "timeout_secs": 60, "working_dir": "/workspace"}
+//   200 OK: {"stdout": "...", "stderr": "...", "exit_code": 0,
+//            "duration_ms": 12, "timed_out": false}
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecRequest {
+    pub command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub working_dir: Option<String>,
+}
+
+/// Server response from POST /exec. Stable schema — agents and the
+/// MCP `run_command` tool depend on it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecResponse {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+    pub duration_ms: u64,
+    pub timed_out: bool,
+}
+
+/// Endpoint construction is deliberately schemed: a stray `https://`
+/// in the host (because the user pasted a URL) shouldn't double-prefix.
+/// We accept either bare host or full base URL and normalize.
+fn normalize_endpoint(host: &str, port: u16) -> String {
+    let h = host.trim();
+    if h.starts_with("http://") || h.starts_with("https://") {
+        // Already a URL — assume the user knows what port they want
+        // and only append the port if the input has no port section.
+        // Heuristic: if there's a colon AFTER the scheme delimiter,
+        // there's already a port.
+        if let Some(rest) = h
+            .strip_prefix("http://")
+            .or_else(|| h.strip_prefix("https://"))
+        {
+            let scheme = if h.starts_with("https://") {
+                "https"
+            } else {
+                "http"
+            };
+            let host_part = rest.split('/').next().unwrap_or(rest);
+            if host_part.contains(':') {
+                return format!("{}://{}", scheme, rest.trim_end_matches('/'));
+            }
+            return format!("{}://{}:{}", scheme, rest.trim_end_matches('/'), port);
+        }
+    }
+    format!("http://{}:{}", h, port)
+}
+
+/// HTTP Basic auth header value. Public so test harnesses can
+/// build the same value the server expects.
+pub fn basic_auth(user: &str, pass: &str) -> String {
+    let creds = format!("{}:{}", user, pass);
+    let encoded = base64::engine::general_purpose::STANDARD.encode(creds);
+    format!("Basic {}", encoded)
+}
+
+/// POST /exec on the agent-sandbox HTTP server. Returns the typed
+/// response. `total_timeout` covers the full HTTP request including
+/// the server-side command runtime — set it slightly above the
+/// `timeout_secs` body field to allow the server to surface a
+/// `timed_out: true` response rather than hitting the client's
+/// transport timeout first.
+pub async fn call_exec(
+    host: &str,
+    port: u16,
+    user: &str,
+    pass: &str,
+    command: &str,
+    timeout_secs: Option<u64>,
+    working_dir: Option<&str>,
+    total_timeout: Duration,
+) -> Result<ExecResponse> {
+    let url = format!("{}/exec", normalize_endpoint(host, port));
+    let body = ExecRequest {
+        command: command.to_string(),
+        timeout_secs,
+        working_dir: working_dir.map(|s| s.to_string()),
+    };
+    let client = reqwest::Client::builder()
+        .timeout(total_timeout)
+        .build()
+        .context("failed to build reqwest client")?;
+    let resp = client
+        .post(&url)
+        .header("Authorization", basic_auth(user, pass))
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("POST {} failed", url))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("exec server returned HTTP {}: {}", status, body);
+    }
+    resp.json::<ExecResponse>()
+        .await
+        .context("exec server response was not the expected JSON shape")
+}
+
+/// Health check for the exec server. Unauthenticated by design (so
+/// the provider can liveness-probe). Returns Ok(()) on 2xx, error
+/// otherwise.
+pub async fn call_health(host: &str, port: u16, total_timeout: Duration) -> Result<()> {
+    let url = format!("{}/health", normalize_endpoint(host, port));
+    let client = reqwest::Client::builder()
+        .timeout(total_timeout)
+        .build()
+        .context("failed to build reqwest client")?;
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .with_context(|| format!("GET {} failed", url))?;
+    if !resp.status().is_success() {
+        anyhow::bail!("health check returned HTTP {}", resp.status());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_bare_host_gets_http_prefix() {
+        assert_eq!(normalize_endpoint("1.2.3.4", 8080), "http://1.2.3.4:8080");
+        assert_eq!(
+            normalize_endpoint("example.com", 8080),
+            "http://example.com:8080"
+        );
+    }
+
+    #[test]
+    fn endpoint_keeps_explicit_scheme() {
+        assert_eq!(
+            normalize_endpoint("http://1.2.3.4", 8080),
+            "http://1.2.3.4:8080"
+        );
+        assert_eq!(
+            normalize_endpoint("https://example.com", 9090),
+            "https://example.com:9090"
+        );
+    }
+
+    #[test]
+    fn endpoint_keeps_explicit_port_in_url() {
+        // If the URL already has a port, we don't override it.
+        assert_eq!(
+            normalize_endpoint("http://1.2.3.4:7777", 8080),
+            "http://1.2.3.4:7777"
+        );
+    }
+
+    #[test]
+    fn endpoint_strips_trailing_slash() {
+        assert_eq!(
+            normalize_endpoint("http://example.com/", 8080),
+            "http://example.com:8080"
+        );
+    }
+
+    #[test]
+    fn basic_auth_matches_servers_python_format() {
+        // Pin the format so a python-side change in server.py would
+        // also need a Rust-side change: both must base64-encode
+        // "user:pass" with standard alphabet.
+        assert_eq!(basic_auth("root", "hunter2"), "Basic cm9vdDpodW50ZXIy");
+    }
+
+    #[test]
+    fn exec_request_omits_optional_fields_when_none() {
+        let r = ExecRequest {
+            command: "ls".to_string(),
+            timeout_secs: None,
+            working_dir: None,
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(!json.contains("timeout_secs"));
+        assert!(!json.contains("working_dir"));
+        assert!(json.contains(r#""command":"ls""#));
+    }
+}

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -5,8 +5,9 @@ use colored::Colorize;
 
 mod api;
 mod commands;
+mod exec_client;
 
-use commands::{batch, bootstrap, deploy, list, mcp, provider, spawn, status, system, topup};
+use commands::{batch, bootstrap, deploy, exec, list, mcp, provider, spawn, status, system, topup};
 
 /// Paygress CLI - Pay-per-Use Compute with Lightning + Nostr
 #[derive(Parser)]
@@ -50,6 +51,10 @@ enum Commands {
     /// can spawn / batch / discover providers as native tools.
     Mcp(mcp::McpArgs),
 
+    /// Run a shell command inside a spawned agent-sandbox workload
+    /// via its baked-in HTTP exec server. Returns stdout/stderr/exit.
+    Exec(exec::ExecArgs),
+
     // ============ Provider Commands ============
     /// Provider management - setup, start, stop, status
     Provider(provider::ProviderArgs),
@@ -92,6 +97,7 @@ async fn main() {
         Commands::Status(args) => status::execute(args, cli.verbose).await,
         Commands::Batch(args) => batch::execute(args, cli.verbose).await,
         Commands::Mcp(args) => mcp::execute(args, cli.verbose).await,
+        Commands::Exec(args) => exec::execute(args, cli.verbose).await,
 
         // Provider
         Commands::Provider(args) => provider::execute(args, cli.verbose).await,

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -904,7 +904,7 @@ async fn handle_spawn_request(
         })
         .unwrap_or_default();
 
-    let template_env: HashMap<String, String> = template
+    let mut template_env: HashMap<String, String> = template
         .as_ref()
         .map(|t| {
             t.env
@@ -913,6 +913,26 @@ async fn handle_spawn_request(
                 .collect()
         })
         .unwrap_or_default();
+
+    // For templates that bake in the paygress-exec HTTP server
+    // (currently `agent-sandbox`), inject the same credentials the
+    // consumer will see in AccessDetails — `root` + the
+    // provider-generated `password`. The instructions block already
+    // tells the consumer to use "root + this password", so the exec
+    // server reusing those creds means there's exactly one secret
+    // to manage per spawn.
+    //
+    // The template defaults EXEC_USER/EXEC_PASS to empty strings;
+    // the server returns 503 until they're non-empty, so this
+    // overlay is what unlocks /exec.
+    if let Some(t) = template.as_ref() {
+        if t.env.contains_key("EXEC_USER") {
+            template_env.insert("EXEC_USER".to_string(), "root".to_string());
+        }
+        if t.env.contains_key("EXEC_PASS") {
+            template_env.insert("EXEC_PASS".to_string(), password.clone());
+        }
+    }
 
     let extra_runtime_args: Vec<String> = template
         .as_ref()

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -287,22 +287,32 @@ fn agent_sandbox() -> TemplateDefinition {
     env.insert("WORKSPACE", "/workspace");
     env.insert("PYTHONUNBUFFERED", "1");
     env.insert("NODE_ENV", "production");
+    // EXEC_USER and EXEC_PASS are the auth credentials for the
+    // baked-in HTTP exec server (images/agent-sandbox/server.py).
+    // Provider's spawn handler overrides these with the consumer's
+    // ssh_username / ssh_password at container-start time so the
+    // caller can use ONE set of creds for both SSH (legacy) and the
+    // exec endpoint. Default values here are placeholders — the
+    // server returns 503 until they're set to non-empty values.
+    env.insert("EXEC_USER", "");
+    env.insert("EXEC_PASS", "");
     TemplateDefinition {
         name: TemplateName::AgentSandbox,
-        summary: "Generic compute sandbox: Python 3.12 + Node 20 + git in a writable /workspace volume. Built for AI agents writing code, CI/test runners, and map-reduce / batch shards. Stateless by default — retry-on-fresh-provider is the recovery model. Browser-using agents should compose with the `headless-browser` template.",
-        // Community-maintained image with Python + Node + git/curl
-        // preinstalled. Battle-tested in the data-engineering /
-        // CI ecosystem; pinned by major version so a registry-side
-        // rebuild doesn't silently change behavior.
-        image: "nikolaik/python-nodejs:python3.12-nodejs20",
+        summary: "Generic compute sandbox: Python 3.12 + Node 20 + git in a writable /workspace volume. Bundled HTTP exec server on port 8080 lets agents run shell commands directly via the `paygress-cli exec` / MCP `run_command` path — no SSH needed. Stateless by default — retry-on-fresh-provider is the recovery model. Browser-using agents should compose with the `headless-browser` template.",
+        // Custom paygress image: nikolaik/python-nodejs +
+        // /usr/local/bin/paygress-exec (the baked-in HTTP server).
+        // Built and published by .github/workflows/agent-sandbox-image.yml
+        // on tags `agent-sandbox-v*`. Pinned to 0.1.0 so a registry-
+        // side rebuild can't silently change spawn behavior.
+        image: "ghcr.io/dhananjaypurohit/paygress-agent-sandbox:0.1.0",
         ports: vec![Port {
-            // One generic HTTP port for agents/jobs that want to
-            // serve results or expose a status endpoint. The host
-            // mapping is published in AccessDetailsContent so the
-            // caller can reach it without scraping the SSH instruction.
+            // The exec server listens here. AccessDetails surfaces
+            // the host_port mapping so the caller can hit
+            // http://<host>:<host_port>/exec with HTTP Basic auth
+            // using the spawn-time ssh_user / ssh_pass.
             container_port: 8080,
             protocol: "http",
-            label: "sandbox-http",
+            label: "sandbox-exec",
         }],
         env,
         compose_path: "templates/agent-sandbox/docker-compose.yml",


### PR DESCRIPTION
## Summary

Closes the killer demo loop on the agent-facing surface. An LLM (or any MCP client) can now:

\`\`\`
spawn_workload(template="agent-sandbox", token=...)   →  host, port, ssh_pass
run_command(host=..., port=..., pass=..., command="python -c '...'")
                                                      →  stdout, stderr, exit_code
\`\`\`

No SSH out-of-band, no manual scp, no second secret to manage. The same credentials Paygress already returns from \`spawn_workload\` are reused for the exec channel.

> Stacks on top of #39 (MCP lifecycle tools). Base branch is \`feat/mcp-lifecycle-tools\`.

## Layout

| File | Purpose |
|------|---------|
| \`images/agent-sandbox/server.py\` | Stdlib-only HTTP exec server, ~150 LOC. POST /exec + GET /health |
| \`images/agent-sandbox/Dockerfile\` | FROM \`nikolaik/python-nodejs:python3.12-nodejs20\` + the server |
| \`.github/workflows/agent-sandbox-image.yml\` | Multi-arch (amd64/arm64) build + push to \`ghcr.io/.../paygress-agent-sandbox\` on tag |
| \`src/cli/exec_client.rs\` | Typed \`reqwest\` client for /exec and /health |
| \`src/cli/commands/exec.rs\` | \`paygress-cli exec --host H --port P --pass P --command "..."\` |
| \`src/cli/commands/mcp.rs\` | New \`run_command\` MCP tool |
| \`src/templates.rs\` | agent-sandbox image flipped to \`ghcr.io/.../paygress-agent-sandbox:0.1.0\` |
| \`src/provider.rs\` | Spawn handler injects \`EXEC_USER\` / \`EXEC_PASS\` from generated SSH creds |

## Wire format

\`\`\`
POST /exec   {command, timeout_secs?, working_dir?}
             → {stdout, stderr, exit_code, duration_ms, timed_out}
GET  /health → 200 ({"status":"ok","workspace":"/workspace"})
\`\`\`

**Auth**: HTTP Basic. Provider injects \`EXEC_USER="root"\` and \`EXEC_PASS=<generated>\` into the container's env at spawn time. The server returns 503 until those are non-empty so anonymous /exec is impossible.

**Server hardening**:
- \`bash -lc\` execution (pipes / redirects work; standard agent-sandbox shape)
- 30-min hard cap on per-request timeout (runaway script can't DoS the lease)
- Health endpoint stays unauthenticated for provider liveness probes
- Threading server so concurrent /exec calls don't serialize

## MCP surface

Six tools now publish via \`tools/list\` (smoke-tested over stdio): \`list_providers\`, \`spawn_workload\`, \`batch_spawn\`, \`workload_status\`, \`topup_workload\`, \`run_command\`. Server's \`instructions\` field updated to call out the canonical \`spawn → run_command\` flow.

## Tests

- 6 exec_client unit tests pin endpoint normalization, \`basic_auth\` format (matches the Python server byte-for-byte: \`Basic cm9vdDpodW50ZXIy\`), and \`skip_serializing_if\` shape on \`ExecRequest\`
- 1 new MCP test pins \`RunCommandParams\` defaults
- Existing \`server_advertises_tool_capability\` test extended to require \`run_command\` in the \`instructions\` hint

Full suite: **125 green**.

## Deferred (image hosting)

The Dockerfile + CI workflow are committed but the actual image at \`ghcr.io/dhananjaypurohit/paygress-agent-sandbox:0.1.0\` needs to be **pushed first** — either manually or by pushing the tag \`agent-sandbox-v0.1.0\` after this PR merges. Until the image is live, agent-sandbox spawns will pull-fail; the previous nikolaik image isn't a fallback (the template now references the custom image directly). Recommend tagging \`agent-sandbox-v0.1.0\` immediately after merge.

## Test plan

- [x] \`cargo test --no-default-features\` (125/125)
- [x] Manual stdio MCP smoke: \`tools/list\` returns all 6 tools
- [ ] Push \`agent-sandbox-v0.1.0\` tag, verify CI publishes the multi-arch image
- [ ] On VPS: spawn agent-sandbox, call \`paygress-cli exec --command "python -c 'print(2+2)'"\`, see \`4\` come back

🤖 Generated with [Claude Code](https://claude.com/claude-code)