### PR TITLE
docs(readme): add 'What you can do' section in plain English

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ https://github.com/user-attachments/assets/627d2bb1-1a9b-4e66-bc42-7c91a1804fe1
 
 Paygress is a marketplace where anyone can buy or sell compute resources using Cashu ecash tokens. Providers advertise on Nostr, consumers discover and pay - all anonymous, all instant.
 
+## What you can do
+
+In plain English, what Paygress lets a user do today:
+
+- **Rent a Linux container by the second.** Hand it a prepaid voucher, get a container running on someone else's machine. No signup, no credit card, no email. The container shuts down when the voucher runs out; extend the lease anytime by handing over another voucher.
+- **Pick from five ready-made boxes.** Generic Python + Node sandbox (with a built-in HTTP exec endpoint — run code without SSH); AI inference endpoint (Ollama, OpenAI-compatible API); Nostr relay; disposable headless Chrome; Bitcoin node.
+- **Run code inside the sandbox without SSH.** The agent-sandbox template ships with a bundled HTTP exec server. POST a command, get back stdout/stderr/exit code. Same credentials as SSH, no extra setup.
+- **Run many containers in parallel.** One command spawns N containers, splits a single voucher N ways automatically, hands you a JSON manifest with each one's address. Built for batch jobs (render farms, ML batch inference), CI matrices (one runner per OS/version), and map-reduce workloads.
+- **Long-running services with automatic failover.** Pay 3 hosts at once (one primary, two standbys). The primary runs the actual container and pings the network every minute. If it stops pinging — machine crashed, network died — the first standby takes over within ~30 seconds, becomes the new primary. (V1 caveat: best-effort single-writer for ~30s during failover; ideal for relays / stateless services, see PR #43 for the full story.)
+- **Let AI assistants do all this for you.** A built-in MCP server plugs into Claude Desktop, Cursor, Cline, Claude Code with one config block. The assistant gets six tools: discover providers, spawn a sandbox, fan out N spawns, monitor a lease, extend a lease, and run code inside the sandbox. So Claude can say *"let me run that for you"* and within seconds has actually executed your code in a sandbox it paid for itself.
+- **Become a host yourself.** Run the provider command on a Linux box you own and start renting compute to anyone with vouchers. Heartbeats publish your availability; consumers find you through discovery. You earn vouchers per second of compute served.
+
 ## Prerequisites
 
 Install Rust via [rustup](https://rustup.rs/):


### PR DESCRIPTION
## Summary

The README jumped straight from one-line tagline to install instructions, leaving a new visitor without a clear picture of what Paygress actually does without reading the code or the architecture section. This PR adds a plain-English capabilities list near the top so the answer to *"what can this do for me?"* is one scroll away.

> Stacks on top of #43 (warm-standby promotion). Base branch is \`feat/standby-promotion\` because the new section claims warm-standby is supported, which is only true once that PR lands.

## What's added

A "## What you can do" section right under the tagline, listing in plain English:

1. Rent a Linux container by the second (anonymous voucher, no signup)
2. Five ready-made templates (sandbox / inference / relay / browser / bitcoin)
3. Run code inside the sandbox without SSH (via the HTTP exec endpoint)
4. Run many containers in parallel (with automatic voucher splitting)
5. Long-running services with **automatic failover** (warm-standby) — listed with the v1 single-writer caveat
6. Plug into AI assistants via MCP (six tools)
7. Become a host yourself

## Why now

Earlier in the PR queue the README's plain-English description had a known caveat: "no long-running stateful services with auto-failover." With #43 closing the warm-standby loop end-to-end, that caveat is no longer true — the fault-tolerance story is complete enough to advertise. The new section reflects that, while honestly noting the v1 best-effort single-writer window during failover so readers know what's strict and what isn't.

## Test plan

- [x] Render the diff locally — section reads cleanly, no jargon spike
- [ ] Confirm in a fresh GitHub view that the section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)