### PR TITLE
feat(templates): add openclaw template (personal AI assistant Gateway)

### DIFF
--- a/src/cli/commands/deploy.rs
+++ b/src/cli/commands/deploy.rs
@@ -76,6 +76,13 @@ pub enum Template {
     /// shards. Stateless by default — retry on a fresh provider is
     /// the recovery model.
     AgentSandbox,
+    /// OpenClaw — open-source personal AI assistant Gateway
+    /// (openclaw.ai). Connects outbound to chat apps and tools;
+    /// keeps memory + per-skill credentials in /data/.openclaw.
+    /// Checkpointed so the user's assistant identity survives a
+    /// provider restart.
+    #[value(name = "openclaw")]
+    OpenClaw,
 }
 
 /// Per-template "what should we do unless told otherwise" table.
@@ -127,6 +134,15 @@ pub const fn template_defaults(t: Template) -> TemplateDefaults {
             image: "nikolaik/python-nodejs:python3.12-nodejs20",
             replication: ReplicationMode::None,
             summary: "Python + Node + git sandbox for agents, CI, and map-reduce shards.",
+        },
+        Template::OpenClaw => TemplateDefaults {
+            tier: "standard",
+            // The provider resolves the real image from its template
+            // registry; this fallback is only consulted when the
+            // provider doesn't recognize the slug.
+            image: "ghcr.io/openclaw/openclaw:latest",
+            replication: ReplicationMode::Checkpointed,
+            summary: "OpenClaw personal AI assistant Gateway; checkpointed.",
         },
     }
 }
@@ -231,6 +247,7 @@ pub async fn execute(args: DeployArgs, verbose: bool) -> Result<()> {
         Template::HeadlessBrowser => "headless-browser",
         Template::BitcoinNode => "bitcoin-node",
         Template::AgentSandbox => "agent-sandbox",
+        Template::OpenClaw => "openclaw",
     };
     // Translate the deploy CLI's replication enum to the spawn CLI's
     // string form. Deploy doesn't yet collect --standby (each

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -51,6 +51,14 @@ pub enum TemplateName {
     /// means "retry from scratch", which is what the upstream caller
     /// already does.
     AgentSandbox,
+    /// OpenClaw — open-source personal AI assistant Gateway
+    /// (openclaw.ai). Connects to chat apps (WhatsApp/Telegram/
+    /// Discord/Slack/Signal/iMessage) outbound, holds persistent
+    /// memory + tool credentials in `~/.openclaw`, exposes a local
+    /// HTTP control plane on 18789 for the user's companion app.
+    /// Checkpointed because the memory + chat-app credentials are
+    /// personal and should survive a provider restart.
+    OpenClaw,
 }
 
 impl TemplateName {
@@ -63,6 +71,7 @@ impl TemplateName {
             Self::HeadlessBrowser => "headless-browser",
             Self::BitcoinNode => "bitcoin-node",
             Self::AgentSandbox => "agent-sandbox",
+            Self::OpenClaw => "openclaw",
         }
     }
 
@@ -73,17 +82,19 @@ impl TemplateName {
             "headless-browser" => Some(Self::HeadlessBrowser),
             "bitcoin-node" => Some(Self::BitcoinNode),
             "agent-sandbox" => Some(Self::AgentSandbox),
+            "openclaw" => Some(Self::OpenClaw),
             _ => None,
         }
     }
 
-    pub fn all() -> [Self; 5] {
+    pub fn all() -> [Self; 6] {
         [
             Self::NostrRelay,
             Self::InferenceEndpoint,
             Self::HeadlessBrowser,
             Self::BitcoinNode,
             Self::AgentSandbox,
+            Self::OpenClaw,
         ]
     }
 }
@@ -154,6 +165,7 @@ impl TemplateDefinition {
             TemplateName::HeadlessBrowser => headless_browser(),
             TemplateName::BitcoinNode => bitcoin_node(),
             TemplateName::AgentSandbox => agent_sandbox(),
+            TemplateName::OpenClaw => openclaw(),
         }
     }
 
@@ -423,5 +435,54 @@ mod tests {
         let def = TemplateDefinition::lookup(TemplateName::AgentSandbox);
         assert_eq!(def.data_path, Some("/workspace"));
         assert_eq!(def.env.get("WORKSPACE"), Some(&"/workspace"));
+    }
+}
+
+fn openclaw() -> TemplateDefinition {
+    let mut env = HashMap::new();
+    // Gateway HTTP control plane bind. The companion app + the
+    // installed-skill webhooks need to hit this; consumers reach it
+    // via the host-port mapping surfaced in AccessDetails.
+    env.insert("OPENCLAW_GATEWAY_PORT", "18789");
+    env.insert("OPENCLAW_GATEWAY_HOST", "0.0.0.0");
+    // Persist config + memory + sessions + per-skill credentials
+    // here so a checkpoint round-trip preserves them. Matches the
+    // upstream default at ~/.openclaw.
+    env.insert("OPENCLAW_CONFIG_DIR", "/data/.openclaw");
+    TemplateDefinition {
+        name: TemplateName::OpenClaw,
+        summary: "OpenClaw — open-source personal AI assistant Gateway (openclaw.ai). Connects outbound to chat apps (WhatsApp/Telegram/Discord/Slack/Signal/iMessage), keeps persistent memory + tool credentials in /data/.openclaw, exposes the Gateway control plane on 18789. Checkpointed because the memory + credentials are personal and should survive provider restarts.",
+        // TODO(openclaw-image): swap to a paygress-pinned image
+        // (`ghcr.io/dhananjaypurohit/paygress-openclaw:<ver>`) once
+        // we publish one — same pattern as agent-sandbox. Today's
+        // best public image is the upstream openclaw repo's own
+        // GHCR build; if upstream stops publishing, deploys break
+        // until the paygress-pinned image lands.
+        image: "ghcr.io/openclaw/openclaw:latest",
+        ports: vec![Port {
+            container_port: 18789,
+            protocol: "http",
+            label: "openclaw-gateway",
+        }],
+        env,
+        compose_path: "templates/openclaw/docker-compose.yml",
+        extra_docker_args: &[],
+        // ~/.openclaw inside the container — config, memory store,
+        // sessions, and per-skill OAuth tokens. The agent's whole
+        // identity lives here; lose it and the user reauthenticates
+        // every chat-app integration.
+        data_path: Some("/data/.openclaw"),
+        tier: "standard",
+        // Personal assistant state is irreplaceable from the
+        // consumer's POV — checkpointed gives them a Blossom-stored
+        // restore point on provider crash. Warm-standby is overkill
+        // (the assistant doesn't need sub-minute recovery).
+        replication: ReplicationMode::Checkpointed,
+        // Node 24 + memory store + concurrent chat-app integrations:
+        // 1 vCPU is fine at idle, 2 GB lets the JS heap breathe under
+        // bursty webhook activity (Telegram + Discord + Slack at once).
+        min_cpu_millicores: 1000,
+        min_memory_mb: 2048,
+        min_storage_gb: 5,
     }
 }

--- a/templates/openclaw/docker-compose.yml
+++ b/templates/openclaw/docker-compose.yml
@@ -1,0 +1,51 @@
+# OpenClaw — open-source personal AI assistant Gateway (openclaw.ai).
+#
+# The Gateway is a local control plane that manages chat-app sessions
+# (WhatsApp/Telegram/Discord/Slack/Signal/iMessage), tools, and
+# memory. It listens on 18789 for the companion app + skill webhooks.
+# Inbound chat-app traffic is NOT served by the Gateway — those
+# integrations are outbound to the upstream APIs / WebSockets.
+#
+# Smoke test (local):
+#   docker compose -f templates/openclaw/docker-compose.yml up -d
+#   curl http://localhost:18789/health
+#   docker logs paygress-openclaw -f
+#
+# First-run setup is interactive: visit http://<host>:18789 in a
+# browser to OAuth-link your chat apps. Credentials persist to the
+# `openclaw-data` volume (mounted at /data/.openclaw inside the
+# container) and survive restarts.
+services:
+  openclaw:
+    # TODO(openclaw-image): swap to a paygress-pinned image once we
+    # publish one (`ghcr.io/dhananjaypurohit/paygress-openclaw:<ver>`).
+    # Tracks the upstream OpenClaw GHCR build today.
+    image: ghcr.io/openclaw/openclaw:latest
+    container_name: paygress-openclaw
+    restart: unless-stopped
+    # Host port is configurable via OPENCLAW_HOST_PORT; defaults to
+    # 18789 to match the upstream documented port.
+    ports:
+      - "${OPENCLAW_HOST_PORT:-18789}:18789"
+    environment:
+      OPENCLAW_GATEWAY_PORT: "18789"
+      OPENCLAW_GATEWAY_HOST: "0.0.0.0"
+      # Persist all stateful data here so a restart preserves the
+      # user's chat-app credentials, memory, and skill config.
+      OPENCLAW_CONFIG_DIR: /data/.openclaw
+    volumes:
+      - openclaw-data:/data/.openclaw
+    # The upstream image's default entrypoint runs the Gateway. If
+    # using a base node image instead, override:
+    #   command: ["openclaw", "gateway", "--port", "18789", "--verbose"]
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - "wget -qO- http://localhost:18789/health >/dev/null 2>&1 || exit 1"
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  openclaw-data:


### PR DESCRIPTION
## Summary

Adds OpenClaw (openclaw.ai) as a 6th killer template. Consumers can now `paygress-cli deploy openclaw --provider <npub> --token <cashu>` to rent compute for an open-source personal AI assistant — chat-app integrations (WhatsApp / Telegram / Discord / Slack / Signal / iMessage), persistent memory, and tool credentials all live inside the rented container.

## Template choices

- **slug**: `openclaw` (not the auto-kebab `open-claw` — overridden with `#[value(name = "openclaw")]`)
- **image**: `ghcr.io/openclaw/openclaw:latest` (upstream's GHCR build). TODO note flags swap to a paygress-pinned image (`ghcr.io/dhananjaypurohit/paygress-openclaw:<ver>`), same pattern as `agent-sandbox`.
- **port**: 18789 — the documented Gateway control-plane port.
- **data_path**: `/data/.openclaw` — config + memory + sessions + per-skill OAuth tokens. Lose it and the user reauthenticates every chat app.
- **replication**: `Checkpointed` — the assistant's identity is irreplaceable from the consumer's POV; warm-standby is overkill for sub-minute recovery.
- **tier**: `standard` (1 vCPU / 2 GB) — Node 24 + memory store + concurrent webhook activity (Telegram + Discord + Slack at once) breathes here.

## Files

- `src/templates.rs` — new `OpenClaw` variant + `openclaw()` factory.
- `src/cli/commands/deploy.rs` — adds the variant to the deploy CLI's `Template` enum, the `template_defaults()` table, and the slug match.
- `templates/openclaw/docker-compose.yml` — operators can `docker compose up` to reproduce locally with no paygress involvement.

## Test plan

- [x] `cargo build --release --no-default-features --bin paygress-cli` clean.
- [x] `paygress-cli deploy --help` lists `openclaw` with its summary.
- [ ] CI green (test / fmt / clippy).
- [ ] Smoke: `docker compose -f templates/openclaw/docker-compose.yml up -d` against a real OpenClaw image once the upstream GHCR tag is verified.
- [ ] End-to-end spawn against TestNode once the provider config whitelists a working mint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)