### PR TITLE
feat(isolation): KVM backend — DedicatedHost tier (no co-tenants)

### DIFF
--- a/docs/plans/kvm-backend-and-isolation-tiers.md
+++ b/docs/plans/kvm-backend-and-isolation-tiers.md
@@ -1,0 +1,195 @@
+# KVM backend + the road from `SharedKernel` → `AttestedResearchTier`
+
+## Why this exists
+
+paygress's marketing promise touches "trustworthy compute marketplace."
+Today's reality is more modest: every spawn is a Docker / LXD container
+on a host the operator owns. The host operator has root, the workload
+runs in their kernel, and any privacy claim against that operator is
+unfounded.
+
+The wire format already encodes three isolation tiers
+(`nostr::IsolationLevel`):
+
+| Tier                       | Defends against co-tenant attacks | Defends against host operator |
+| -------------------------- | --------------------------------- | ----------------------------- |
+| `SharedKernel`             | ❌                                 | ❌                             |
+| `DedicatedHost`            | ✅                                 | ❌                             |
+| `AttestedResearchTier`     | ✅                                 | ✅                             |
+
+Until this PR, every backend published `SharedKernel`. This PR ships
+the second tier and lays out the path to the third.
+
+## What this PR ships (`DedicatedHost`)
+
+A new `KvmBackend` (`src/kvm.rs`) that implements `ComputeBackend` by
+spawning a per-workload qemu/KVM virtual machine. Selected via
+`backend_type: kvm` in the provider config; the offer it publishes
+sets `isolation_level: dedicated-host` so consumers filtering by
+isolation tier match it.
+
+### Boundary
+
+A regular VM (no SEV-SNP) closes the **kernel-shared** attack
+surface:
+
+- A workload exploiting a kernel CVE owns the VM's kernel, not the
+  host's. Container-escape exploits don't apply.
+- Co-tenants on the same host can't reach each other through cgroup /
+  namespace bugs — they're in different VMs with different kernels,
+  different memory, different device trees.
+- Host kernel bugs that affect cgroup/namespace/seccomp do not affect
+  the guest.
+
+But the host operator with root on the hypervisor can still:
+
+- Dump guest RAM via `virsh qemu-monitor-command <vm> 'pmemsave 0
+  <ram> /tmp/dump.raw'`.
+- Attach a debugger to the qemu process: `gdb -p <qemu-pid>`.
+- Read the guest disk image (qcow2) at any time, mounted via
+  `qemu-nbd` even while the VM runs.
+- Tap the VM's network bridge with `tcpdump -i any`.
+- Modify the guest kernel before boot.
+
+So `DedicatedHost` is **isolation from co-tenants, not confidentiality
+from the operator.** The doc-comment on `KvmBackend` says this; the
+tier name says this; we should also say it on the website.
+
+### What runs inside
+
+Vanilla Ubuntu 22.04 cloud image with cloud-init. Consumer SSHes in
+on the spawn-time host port. Killer-template Docker images (#31) are
+NOT served on the KVM backend in v1: those templates assume the host
+runs Docker, but the KVM guest is a fresh VM with no `dockerd`. A
+follow-up PR can run cloud-init userdata that installs Docker +
+the template image, but that's deferred so this PR is reviewable.
+
+### What we deliberately did not solve in v1
+
+1. **Templates inside the VM.** Out of scope; vanilla Ubuntu only.
+2. **`template_ports` beyond SSH.** The qemu argv builder supports
+   multiple `hostfwd` entries, but the consumer-facing `--port`
+   surface lands with the templates-on-VMs follow-up.
+3. **`data_path` encryption.** The whole VM disk is one qcow2 file;
+   LUKS-on-loop (PR #47) doesn't apply directly. Consumer-encrypted
+   guest disks via LUKS-inside-the-guest is a follow-up.
+4. **Crash recovery.** A startup-time `pidfile-and-process-still-
+   alive?` sweep that re-claims orphaned VMs lands separately.
+
+## The road to `AttestedResearchTier` (SEV-SNP)
+
+The KVM backend is structured so the SEV-SNP backend is a small
+delta on top, not a parallel implementation. When we have an AMD
+EPYC 7003+ host (Hetzner CCX13, Azure DCasv5, AWS m6a), the work is:
+
+1. **Add SEV-SNP qemu flags.** `-machine
+   confidential-guest-support=sev-snp,memory-backend=ram0` plus an
+   `-object sev-snp-guest,id=sev-snp,...` definition. ~20 lines in
+   `qemu_argv` behind a `confidential: bool` config knob.
+2. **Measured boot chain.** Replace the cloud image with a kernel +
+   initrd we measure. Boot via `-kernel` and `-initrd` rather than
+   the cloud image's grub. Measurement = SHA-384 of (kernel || initrd
+   || cmdline). Reproducible by the consumer locally so the
+   attestation report can be verified.
+3. **Attestation handshake.** Add a two-phase commit to the spawn
+   protocol:
+   - Phase 1: consumer sends spawn request (no Cashu token), provider
+     returns an attestation report from `/dev/sev-guest`. Consumer
+     verifies the AMD-PSP signature against AMD's KDS (key
+     distribution service) and checks the measured boot value
+     matches the kernel+initrd they expect.
+   - Phase 2: consumer sends the Cashu token, provider unlocks the
+     LUKS-keyed disk with the key delivered alongside it.
+   - Wire format additions:
+     - `EncryptedSpawnPodRequest.attestation_required: bool`
+     - `AccessDetailsContent.attestation_report: Option<...>`
+     - New `Phase1AttestationResponse` private message kind.
+4. **Consumer-side verifier.** Pull in
+   `sev` crate (`anjuna-security/sev` or `virtee/sev`) for the AMD
+   attestation signature verification. ~200 lines of consumer-side
+   code, mostly serde + cryptographic verification.
+5. **Provider startup check.** `cat /sys/module/kvm_amd/parameters/sev_snp`
+   must be `Y` (or equivalent). Fail-fast if not.
+
+Estimated total: **~1 week of focused work, plus 2-3 days of
+end-to-end validation on a real EPYC host.** The bottleneck is
+having a host to develop against, not the code.
+
+### Why we didn't ship this in this PR
+
+We don't have a SEV-SNP-capable host. Writing the qemu invocation,
+the attestation handshake, and the verifier without a host to run
+them against would produce code that nobody could test. That's worse
+than no code: it ships untrue claims about confidentiality. Ship the
+backend that works on a normal VPS today (`DedicatedHost`); ship the
+SEV-SNP one when an EPYC host is provisioned.
+
+### Where to get a SEV-SNP host
+
+| Provider          | Product                | Approx cost                |
+| ----------------- | ---------------------- | -------------------------- |
+| Hetzner           | CCX13 (AMD EPYC 7003)  | ~€30/mo, dedicated         |
+| Azure             | DCasv5                 | ~$0.20/hr on demand        |
+| AWS               | m6a / c7a + Nitro      | ~$0.10/hr (different model)|
+| GCP               | Confidential Compute   | ~$0.12/hr                  |
+
+Hetzner CCX13 is the dev-loop sweet spot: dedicated, predictable, no
+per-second billing surprises.
+
+## Provider operator: how to use the KVM backend
+
+```bash
+# 1. Verify your host has KVM (most bare-metal Linux + many VPSes).
+ls /dev/kvm        # must exist
+qemu-system-x86_64 --version
+
+# 2. Update provider-config.json:
+#    "backend_type": "Kvm"
+#
+#    The backend will download the Ubuntu cloud image to
+#    /var/lib/paygress/vm/base/ on first spawn (~600 MB).
+
+# 3. Restart paygress-provider.
+systemctl restart paygress-provider
+
+# 4. Verify the offer now publishes dedicated-host:
+paygress-cli list info <your-npub> | grep -i isolation
+
+# Expected: "Isolation: dedicated-host"
+```
+
+Consumers explicitly opt in to the higher isolation tier via the
+existing `--isolation-level` flag (Unit 22, follow-up):
+
+```bash
+paygress-cli list --isolation-level dedicated-host
+paygress-cli spawn --isolation-level dedicated-host --provider <npub> ...
+```
+
+(The consumer-side filter UI is a separate PR; today the offer
+publishes the right tier and forward-compatible clients can already
+filter on it.)
+
+## Acceptance test (run on a KVM-enabled host)
+
+```bash
+# 1. Start provider with backend_type: Kvm
+paygress-cli provider start --config /etc/paygress/provider-config.json
+
+# 2. From a fresh consumer identity, spawn a VM
+paygress-cli spawn --provider <npub> --token <cashu> --tier basic \
+    --ssh-pass "MyPass2026"
+
+# 3. Expected: AccessDetails returns ssh -p <port> root@<host>;
+#    behind the scenes a qemu VM is running with its own kernel.
+
+# 4. Inside the VM, prove the kernel is NOT the host's:
+ssh -p <port> root@<host> 'uname -r'   # different from host's uname -r
+
+# 5. Check isolation: try escape vectors that work on Docker but not VMs
+ssh -p <port> root@<host> '
+    cat /proc/1/status | grep CapEff;          # full caps inside VM
+    ls /sys/fs/cgroup;                         # VM-private cgroup
+    mount;                                     # VM-private mount ns
+'
+```

--- a/src/cli/commands/provider.rs
+++ b/src/cli/commands/provider.rs
@@ -332,6 +332,12 @@ async fn execute_start(args: StartArgs, verbose: bool) -> Result<()> {
             println!("  Backend:  Docker");
             println!("  Note:     templates require Docker; ensure `docker` is on PATH");
         }
+        paygress::provider::BackendType::Kvm => {
+            println!("  Backend:  KVM/qemu (per-VM isolation, dedicated-host tier)");
+            println!(
+                "  Note:     requires /dev/kvm + qemu-system-x86_64; killer templates not served"
+            );
+        }
     }
     println!();
 

--- a/src/kvm.rs
+++ b/src/kvm.rs
@@ -1,0 +1,612 @@
+// KVM/qemu compute backend.
+//
+// Implements `ComputeBackend` by spawning a per-workload
+// qemu/KVM virtual machine. Each spawn is its own VM with its own
+// kernel, virtio devices, and disk. The host operator running on the
+// hypervisor can still see the guest's memory (no SEV-SNP), but
+// every container-escape path that exists in the Docker / LXD
+// backends is closed by the VM boundary.
+//
+// Where this fits in paygress's isolation tiers
+// ----------------------------------------------
+// (See `nostr::IsolationLevel`.)
+//   - `SharedKernel`        : Docker / LXD (today's default backends).
+//                             Cheapest, fastest, leakiest.
+//   - `DedicatedHost`       : THIS BACKEND. Per-workload VM. Defends
+//                             against co-tenant attacks and container
+//                             escape exploits. Does NOT defend against
+//                             the host operator with hypervisor root.
+//   - `AttestedResearchTier`: SEV-SNP / TDX. Defends against the
+//                             host operator. Needs hardware (AMD
+//                             EPYC 7003+ / Intel Sapphire Rapids).
+//                             This module is the foundation that
+//                             tier will extend — when an EPYC host
+//                             is provisioned, the changes are:
+//                               * `-machine confidential-guest-support=...`
+//                               * an attestation handshake before
+//                                 the consumer sends the spawn token
+//                               * a measured boot chain (kernel +
+//                                 initrd) the consumer can verify
+//                             Everything else (cloud-init seed, disk
+//                             overlay, network forwarding) reuses
+//                             this code unchanged.
+//
+// Why qemu+KVM and not Firecracker / Cloud Hypervisor
+// ----------------------------------------------------
+// qemu's larger surface buys us cloud-init compatibility (so we get
+// SSH onto a vanilla Ubuntu image without baking custom userdata
+// into a Firecracker rootfs), virtio device flexibility (we may add
+// a virtio-vsock channel later for the agent-sandbox HTTP exec
+// equivalent), and the eventual SEV-SNP path. Cold-start is slower
+// than Firecracker (~3-5s vs ~125ms) but the boot is amortized over
+// a multi-hour-to-multi-day workload lease — not a hot path.
+//
+// Storage layout
+// --------------
+// /var/lib/paygress/vm/base/<image>.img      — read-only cloud image
+// /var/lib/paygress/vm/<id>/disk.qcow2       — per-VM overlay
+// /var/lib/paygress/vm/<id>/seed.iso         — cloud-init seed
+// /var/lib/paygress/vm/<id>/qemu.pid         — qemu daemon pidfile
+// /var/lib/paygress/vm/<id>/serial.log       — guest serial console
+//
+// What this v1 deliberately does NOT do
+// -------------------------------------
+//   - Run the killer-template Docker images. The KVM backend serves
+//     a vanilla Ubuntu VM; consumers shell in via SSH and run their
+//     own software. Running templates inside a VM would require
+//     nested-Docker bootstrap inside cloud-init — out of scope here,
+//     tracked as a follow-up.
+//   - Honor `ContainerConfig.template_ports` beyond SSH. Each VM
+//     gets ONE host-port forward (the `host_port` field) for SSH;
+//     forwarding additional template ports lands when the v2
+//     template-aware path does.
+//   - Persistent data volumes (`data_path`). The VM's qcow2 disk IS
+//     the persistent state; LUKS-on-loop encryption from the Docker
+//     path doesn't apply (the disk is one file). Consumer-encrypted
+//     disks via LUKS-inside-the-guest is a follow-up.
+//   - Cleanup of VMs orphaned by a provider crash. A startup-time
+//     `pidfile-and-process-still-alive?` sweep lands separately.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use tokio::process::Command;
+use tracing::{debug, info, warn};
+
+use crate::compute::{ComputeBackend, ContainerConfig, NodeStatus};
+
+/// Root directory for paygress-managed VMs.
+const VM_ROOT: &str = "/var/lib/paygress/vm";
+
+/// Default base image. Ubuntu 22.04 cloud image — small (~600 MB),
+/// has cloud-init preinstalled, well-supported across hosting
+/// providers. Operators can override via `KvmConfig`.
+const DEFAULT_BASE_IMAGE_URL: &str =
+    "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img";
+const DEFAULT_BASE_IMAGE_FILE: &str = "jammy-server-cloudimg-amd64.img";
+
+/// Per-instance configuration for the KVM backend. Provider
+/// operators tweak these at startup.
+#[derive(Debug, Clone)]
+pub struct KvmConfig {
+    /// Path to the read-only base cloud image. The backend creates
+    /// per-VM qcow2 overlays on top, so multiple workloads share one
+    /// physical base. Downloaded on first spawn if absent.
+    pub base_image_path: PathBuf,
+    /// URL the backend fetches the base image from when
+    /// `base_image_path` is missing. Defaults to the Ubuntu cloud
+    /// image.
+    pub base_image_url: String,
+    /// Where per-VM directories live.
+    pub vm_root: PathBuf,
+}
+
+impl Default for KvmConfig {
+    fn default() -> Self {
+        Self {
+            base_image_path: PathBuf::from(VM_ROOT)
+                .join("base")
+                .join(DEFAULT_BASE_IMAGE_FILE),
+            base_image_url: DEFAULT_BASE_IMAGE_URL.to_string(),
+            vm_root: PathBuf::from(VM_ROOT),
+        }
+    }
+}
+
+/// KVM/qemu backend.
+pub struct KvmBackend {
+    config: KvmConfig,
+}
+
+impl KvmBackend {
+    pub fn new(config: KvmConfig) -> Self {
+        Self { config }
+    }
+
+    fn vm_dir(&self, id: u32) -> PathBuf {
+        self.config.vm_root.join(id.to_string())
+    }
+
+    fn disk_path(&self, id: u32) -> PathBuf {
+        self.vm_dir(id).join("disk.qcow2")
+    }
+
+    fn seed_path(&self, id: u32) -> PathBuf {
+        self.vm_dir(id).join("seed.iso")
+    }
+
+    fn pidfile_path(&self, id: u32) -> PathBuf {
+        self.vm_dir(id).join("qemu.pid")
+    }
+
+    fn serial_log_path(&self, id: u32) -> PathBuf {
+        self.vm_dir(id).join("serial.log")
+    }
+
+    /// Verify qemu + KVM support is present. Provider should call
+    /// this at startup; surfacing "your host doesn't support KVM"
+    /// at config time is much better than at first-spawn time.
+    pub async fn check_kvm_available() -> Result<String> {
+        if !PathBuf::from("/dev/kvm").exists() {
+            anyhow::bail!(
+                "/dev/kvm not present; this host does not support KVM. \
+                 Use the Docker or LXD backend, or move to a host with \
+                 nested virtualization enabled."
+            );
+        }
+        let out = Command::new("qemu-system-x86_64")
+            .arg("--version")
+            .output()
+            .await
+            .context("qemu-system-x86_64 not found on PATH; install qemu-system-x86")?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "qemu-system-x86_64 --version failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .next()
+            .unwrap_or("")
+            .to_string())
+    }
+
+    /// Ensure the base image is present, downloading on first call.
+    /// Idempotent: subsequent calls no-op.
+    async fn ensure_base_image(&self) -> Result<()> {
+        if self.config.base_image_path.exists() {
+            return Ok(());
+        }
+        let parent = self
+            .config
+            .base_image_path
+            .parent()
+            .context("base_image_path has no parent")?;
+        tokio::fs::create_dir_all(parent)
+            .await
+            .context("create base image directory")?;
+        info!(
+            "Downloading base image from {} to {}",
+            self.config.base_image_url,
+            self.config.base_image_path.display()
+        );
+        let out = Command::new("curl")
+            .args([
+                "-fsSL",
+                "-o",
+                self.config.base_image_path.to_string_lossy().as_ref(),
+                &self.config.base_image_url,
+            ])
+            .output()
+            .await
+            .context("invoke curl to fetch base image")?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "curl failed to fetch base image: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    }
+
+    /// Cloud-init userdata: enable SSH password auth, set the root
+    /// password the consumer supplied. Yes, password auth — not key
+    /// auth — because the consumer already trusts this provider with
+    /// the password (it lived in the spawn DM); requiring an extra
+    /// pubkey upload is friction without a security gain when the
+    /// VM is single-tenant.
+    fn user_data(password: &str) -> String {
+        format!(
+            "#cloud-config\n\
+             ssh_pwauth: true\n\
+             disable_root: false\n\
+             chpasswd:\n  \
+               list: |\n    \
+                 root:{}\n  \
+               expire: false\n\
+             # Keep the boot fast: skip waiting for slow services.\n\
+             timezone: Etc/UTC\n",
+            password
+        )
+    }
+
+    fn meta_data(id: u32) -> String {
+        format!(
+            "instance-id: paygress-{0}\nlocal-hostname: paygress-{0}\n",
+            id
+        )
+    }
+
+    /// Build the cloud-init seed ISO. Uses `genisoimage` — the
+    /// `cloud-localds` wrapper would be more concise but it's
+    /// less universally available across distros.
+    async fn make_seed_iso(&self, id: u32, password: &str) -> Result<()> {
+        let dir = self.vm_dir(id);
+        let user_path = dir.join("user-data");
+        let meta_path = dir.join("meta-data");
+        tokio::fs::write(&user_path, Self::user_data(password))
+            .await
+            .context("write user-data")?;
+        tokio::fs::write(&meta_path, Self::meta_data(id))
+            .await
+            .context("write meta-data")?;
+        let out = Command::new("genisoimage")
+            .args([
+                "-output",
+                self.seed_path(id).to_string_lossy().as_ref(),
+                "-volid",
+                "cidata",
+                "-joliet",
+                "-rock",
+                user_path.to_string_lossy().as_ref(),
+                meta_path.to_string_lossy().as_ref(),
+            ])
+            .output()
+            .await
+            .context("invoke genisoimage")?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "genisoimage failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    }
+
+    /// Build the qemu-system-x86_64 argv. Pure function — testable
+    /// without spawning anything. Caller is responsible for the seed
+    /// ISO + qcow2 already existing.
+    pub fn qemu_argv(&self, config: &ContainerConfig) -> Vec<String> {
+        let id = config.id;
+        let cores = config.cpu_cores.max(1);
+        let mem_mb = config.memory_mb.max(512);
+        let host_port = config.host_port.unwrap_or(0);
+
+        // user-mode networking + hostfwd: SSH always, plus any
+        // template ports the consumer asked for.
+        let mut hostfwds = vec![format!("hostfwd=tcp::{}-:22", host_port)];
+        for p in &config.template_ports {
+            hostfwds.push(format!(
+                "hostfwd={}::{}-:{}",
+                p.protocol, p.host_port, p.container_port
+            ));
+        }
+        let netdev = format!("user,id=net0,{}", hostfwds.join(","));
+
+        vec![
+            // Acceleration + CPU model: -enable-kvm uses the host's
+            // KVM module; -cpu host passes through the physical CPU
+            // features so guests can use AES-NI / AVX / etc.
+            "-enable-kvm".to_string(),
+            "-cpu".to_string(),
+            "host".to_string(),
+            "-machine".to_string(),
+            "type=q35,accel=kvm".to_string(),
+            "-smp".to_string(),
+            cores.to_string(),
+            "-m".to_string(),
+            mem_mb.to_string(),
+            // Primary disk: per-VM qcow2 overlay on the read-only base.
+            "-drive".to_string(),
+            format!(
+                "file={},if=virtio,format=qcow2",
+                self.disk_path(id).display()
+            ),
+            // Cloud-init seed: rom image, qemu picks it up at boot.
+            "-drive".to_string(),
+            format!(
+                "file={},if=virtio,format=raw,readonly=on",
+                self.seed_path(id).display()
+            ),
+            "-netdev".to_string(),
+            netdev,
+            "-device".to_string(),
+            "virtio-net-pci,netdev=net0".to_string(),
+            // Daemonize + pidfile so we can manage the lifecycle
+            // post-spawn via the pid (kill / wait).
+            "-daemonize".to_string(),
+            "-pidfile".to_string(),
+            self.pidfile_path(id).to_string_lossy().to_string(),
+            // No graphical console; serial captured to a file for
+            // operator debugging when a guest fails to boot.
+            "-nographic".to_string(),
+            "-serial".to_string(),
+            format!("file:{}", self.serial_log_path(id).display()),
+        ]
+    }
+
+    async fn create_overlay_disk(&self, id: u32, size_gb: u32) -> Result<()> {
+        // qemu-img create -f qcow2 -b <base> -F qcow2 <overlay> <size>G
+        // The -b backing-file + -F backing-format pair makes the
+        // overlay reference the base; only modified blocks live in
+        // the overlay.
+        let out = Command::new("qemu-img")
+            .args([
+                "create",
+                "-f",
+                "qcow2",
+                "-b",
+                self.config.base_image_path.to_string_lossy().as_ref(),
+                "-F",
+                "qcow2",
+                self.disk_path(id).to_string_lossy().as_ref(),
+                &format!("{}G", size_gb.max(5)),
+            ])
+            .output()
+            .await
+            .context("invoke qemu-img create")?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "qemu-img create failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    }
+
+    /// Read the daemonized qemu's PID from its pidfile.
+    async fn read_pid(&self, id: u32) -> Option<i32> {
+        let p = self.pidfile_path(id);
+        let bytes = tokio::fs::read_to_string(&p).await.ok()?;
+        bytes.trim().parse().ok()
+    }
+}
+
+#[async_trait]
+impl ComputeBackend for KvmBackend {
+    /// Scan vm_root for existing per-id directories and pick the
+    /// next free id in range.
+    async fn find_available_id(&self, range_start: u32, range_end: u32) -> Result<u32> {
+        let mut used = std::collections::HashSet::new();
+        if let Ok(mut entries) = tokio::fs::read_dir(&self.config.vm_root).await {
+            while let Ok(Some(entry)) = entries.next_entry().await {
+                if let Some(name) = entry.file_name().to_str() {
+                    if let Ok(n) = name.parse::<u32>() {
+                        used.insert(n);
+                    }
+                }
+            }
+        }
+        for id in range_start..=range_end {
+            if !used.contains(&id) {
+                return Ok(id);
+            }
+        }
+        anyhow::bail!(
+            "no available VM id in range {}..={}",
+            range_start,
+            range_end
+        );
+    }
+
+    async fn create_container(&self, config: &ContainerConfig) -> Result<String> {
+        let id = config.id;
+        info!(
+            "Provisioning KVM VM: id={} cores={} mem={}MB disk={}GB",
+            id, config.cpu_cores, config.memory_mb, config.storage_gb
+        );
+
+        self.ensure_base_image().await?;
+
+        let dir = self.vm_dir(id);
+        tokio::fs::create_dir_all(&dir)
+            .await
+            .context("create vm directory")?;
+
+        self.create_overlay_disk(id, config.storage_gb)
+            .await
+            .context("create overlay disk")?;
+        self.make_seed_iso(id, &config.password)
+            .await
+            .context("build cloud-init seed iso")?;
+
+        let argv = self.qemu_argv(config);
+        debug!("qemu argv: {:?}", argv);
+        let arg_refs: Vec<&str> = argv.iter().map(|s| s.as_str()).collect();
+        let out = Command::new("qemu-system-x86_64")
+            .args(&arg_refs)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .context("invoke qemu-system-x86_64")?;
+        if !out.status.success() {
+            // qemu's own error landed on stderr; surface it to the
+            // operator so a "missing /dev/kvm" or "image not found"
+            // is obvious.
+            anyhow::bail!(
+                "qemu-system-x86_64 failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+
+        let pid = self
+            .read_pid(id)
+            .await
+            .context("qemu daemonized but pidfile missing — boot failed before pidfile write?")?;
+        info!("KVM VM id={} live (pid {})", id, pid);
+        Ok(format!("paygress-vm-{}", id))
+    }
+
+    /// Daemonized qemu starts on `create_container`; this is a no-op
+    /// since the lifecycle is single-shot. If we ever migrate to a
+    /// non-daemonized qemu (e.g. for live migration support),
+    /// `start_container` becomes the place that spawns the process.
+    async fn start_container(&self, _id: u32) -> Result<()> {
+        Ok(())
+    }
+
+    async fn stop_container(&self, id: u32) -> Result<()> {
+        if let Some(pid) = self.read_pid(id).await {
+            // Best-effort SIGTERM; qemu shuts down its guest cleanly
+            // when it receives SIGTERM (sends ACPI power button).
+            let _ = Command::new("kill")
+                .args(["-TERM", &pid.to_string()])
+                .status()
+                .await;
+        }
+        Ok(())
+    }
+
+    async fn delete_container(&self, id: u32) -> Result<()> {
+        // Stop first (idempotent if already gone), then nuke the dir.
+        let _ = self.stop_container(id).await;
+        if let Some(pid) = self.read_pid(id).await {
+            // If TERM didn't take, escalate after a short wait.
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            let _ = Command::new("kill")
+                .args(["-KILL", &pid.to_string()])
+                .status()
+                .await;
+        }
+        let dir = self.vm_dir(id);
+        if dir.exists() {
+            if let Err(e) = tokio::fs::remove_dir_all(&dir).await {
+                warn!("remove {} non-fatal: {}", dir.display(), e);
+            }
+        }
+        Ok(())
+    }
+
+    async fn get_node_status(&self) -> Result<NodeStatus> {
+        // Same minimal report as DockerBackend; a sysinfo-backed
+        // implementation lands in a follow-up.
+        Ok(NodeStatus {
+            cpu_usage: 0.0,
+            memory_used: 0,
+            memory_total: 0,
+            disk_used: 0,
+            disk_total: 0,
+        })
+    }
+
+    async fn get_container_ip(&self, _id: u32) -> Result<Option<String>> {
+        // Guest is reachable via the host's IP + the SSH host_port
+        // forward. We don't expose the guest's internal 10.0.2.x IP
+        // because user-mode networking NATs everything.
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compute::PortMapping;
+
+    fn cfg(id: u32) -> ContainerConfig {
+        ContainerConfig {
+            id,
+            name: format!("paygress-vm-{}", id),
+            image: String::new(), // ignored by KVM v1
+            cpu_cores: 2,
+            memory_mb: 2048,
+            storage_gb: 10,
+            password: "secret".to_string(),
+            ssh_key: None,
+            host_port: Some(31000),
+            template_ports: vec![PortMapping {
+                host_port: 18789,
+                container_port: 18789,
+                protocol: "tcp",
+            }],
+            template_env: Default::default(),
+            extra_runtime_args: vec![],
+            data_path: None,
+            volume_encryption_key: None,
+        }
+    }
+
+    #[test]
+    fn qemu_argv_includes_kvm_acceleration_and_cpu_host() {
+        let backend = KvmBackend::new(KvmConfig::default());
+        let argv = backend.qemu_argv(&cfg(42));
+        assert!(argv.iter().any(|a| a == "-enable-kvm"));
+        let cpu_idx = argv.iter().position(|a| a == "-cpu").unwrap();
+        assert_eq!(argv[cpu_idx + 1], "host");
+    }
+
+    #[test]
+    fn qemu_argv_forwards_ssh_and_template_ports() {
+        let backend = KvmBackend::new(KvmConfig::default());
+        let argv = backend.qemu_argv(&cfg(42));
+        let netdev = argv
+            .iter()
+            .position(|a| a == "-netdev")
+            .map(|i| argv[i + 1].clone())
+            .unwrap();
+        assert!(
+            netdev.contains("hostfwd=tcp::31000-:22"),
+            "ssh hostfwd missing in: {netdev}"
+        );
+        assert!(
+            netdev.contains("hostfwd=tcp::18789-:18789"),
+            "template hostfwd missing in: {netdev}"
+        );
+    }
+
+    #[test]
+    fn qemu_argv_pidfile_and_disk_paths_are_id_scoped() {
+        let backend = KvmBackend::new(KvmConfig::default());
+        let argv = backend.qemu_argv(&cfg(7));
+        let pidfile_idx = argv.iter().position(|a| a == "-pidfile").unwrap();
+        assert!(argv[pidfile_idx + 1].contains("/7/qemu.pid"));
+        let drives: Vec<&String> = argv
+            .iter()
+            .enumerate()
+            .filter(|(i, a)| *a == "-drive" && *i + 1 < argv.len())
+            .map(|(i, _)| &argv[i + 1])
+            .collect();
+        assert!(drives.iter().any(|d| d.contains("/7/disk.qcow2")));
+        assert!(drives.iter().any(|d| d.contains("/7/seed.iso")));
+    }
+
+    #[test]
+    fn qemu_argv_memory_floor() {
+        let backend = KvmBackend::new(KvmConfig::default());
+        let mut tiny = cfg(1);
+        tiny.memory_mb = 64; // way below qemu's reasonable floor
+        let argv = backend.qemu_argv(&tiny);
+        let m_idx = argv.iter().position(|a| a == "-m").unwrap();
+        assert_eq!(argv[m_idx + 1], "512", "must clamp to 512 MB minimum");
+    }
+
+    #[test]
+    fn paths_are_id_scoped_and_under_vm_root() {
+        let backend = KvmBackend::new(KvmConfig::default());
+        for (a, b) in [(1u32, 2u32), (10, 20), (999, 1000)] {
+            assert_ne!(backend.vm_dir(a), backend.vm_dir(b));
+            assert_ne!(backend.disk_path(a), backend.disk_path(b));
+            assert!(backend.vm_dir(a).starts_with(VM_ROOT));
+        }
+    }
+
+    #[test]
+    fn user_data_includes_password_and_enables_pwauth() {
+        let ud = KvmBackend::user_data("hunter2");
+        assert!(ud.contains("ssh_pwauth: true"));
+        assert!(ud.contains("root:hunter2"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod volume_encryption;
 pub mod compute;
 pub mod discovery;
 pub mod docker;
+pub mod kvm;
 pub mod luks;
 pub mod lxd;
 pub mod provider;

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -41,6 +41,15 @@ pub enum BackendType {
     /// can't run natively. Provider must have the `docker` CLI
     /// installed and accessible to the running user.
     Docker,
+    /// KVM/qemu backend. Each spawn is its own VM with its own
+    /// kernel — no co-tenant attacks via container escape.
+    /// Publishes `IsolationLevel::DedicatedHost` on the offer so
+    /// consumers filtering by `--isolation-level dedicated-host`
+    /// match this provider. Requires `/dev/kvm` and
+    /// `qemu-system-x86_64` on the host. Killer templates (Docker
+    /// images) are NOT served on this backend in v1; consumers get
+    /// vanilla Ubuntu VMs with SSH access.
+    Kvm,
 }
 
 impl Default for BackendType {
@@ -273,6 +282,17 @@ impl ProviderService {
                 &config.proxmox_bridge,  // Reuse bridge for network
             )),
             BackendType::Docker => Arc::new(DockerBackend::new()),
+            BackendType::Kvm => {
+                // Fail-fast: surface the "this host doesn't have
+                // KVM" error at provider startup, not at first
+                // spawn (when a paying consumer has already
+                // committed a Cashu token).
+                if let Err(e) = crate::kvm::KvmBackend::check_kvm_available().await {
+                    tracing::error!("KVM backend selected but unavailable: {}", e);
+                    anyhow::bail!("KVM backend unavailable: {}", e);
+                }
+                Arc::new(crate::kvm::KvmBackend::new(crate::kvm::KvmConfig::default()))
+            }
         };
 
         // Initialize Nostr client
@@ -373,7 +393,17 @@ impl ProviderService {
             total_jobs_completed: stats.total_jobs_completed,
             api_endpoint: None, // TODO: Add if supporting direct API
             version: crate::nostr::SCHEMA_VERSION,
-            isolation_level: crate::nostr::IsolationLevel::SharedKernel,
+            // Derive isolation tier from the configured backend.
+            // KVM is per-VM (DedicatedHost). Docker / LXD / Proxmox
+            // share the host kernel (SharedKernel) — same tier as
+            // historical default. SEV-SNP / TDX gets its own
+            // backend later and bumps to AttestedResearchTier.
+            isolation_level: match self.config.backend_type {
+                BackendType::Kvm => crate::nostr::IsolationLevel::DedicatedHost,
+                BackendType::Proxmox | BackendType::LXD | BackendType::Docker => {
+                    crate::nostr::IsolationLevel::SharedKernel
+                }
+            },
             stake_proof: None,
         };
 


### PR DESCRIPTION
## Summary

Adds a new compute backend that spawns one **qemu/KVM VM per workload** instead of a Docker container. Provider opts in via `backend_type: Kvm`; the offer it publishes sets `isolation_level: dedicated-host` (the wire format from PR #21 — finally honored by a real backend).

## Why

paygress's marketing brushes "trustworthy compute marketplace." Today every spawn is a Docker / LXD container on a host the operator owns — the host has root, the workload runs in their kernel, and any privacy claim against that operator is unfounded. The wire format already encodes three isolation tiers; until this PR every backend published the leakiest one.

| Tier | Defends co-tenant attacks | Defends host operator | Backend |
|---|---|---|---|
| `SharedKernel` | ❌ | ❌ | Docker / LXD / Proxmox (today) |
| `DedicatedHost` | ✅ | ❌ | **KVM (this PR)** |
| `AttestedResearchTier` | ✅ | ✅ | SEV-SNP (needs hardware) |

## Boundary (re-stated, both in code-comments and the design doc)

**Defends:**
- Container-escape exploits — a workload owns the VM's kernel, not the host's.
- Co-tenant attacks via cgroup / namespace / seccomp bugs — different VMs, different kernels, different memory.
- Host kernel CVEs against the cgroup/namespace stack.

**Does NOT defend (the operator with hypervisor root):**
- `virsh qemu-monitor-command pmemsave` reads guest RAM at any time.
- `gdb -p <qemu-pid>` attaches to the qemu process and walks guest memory.
- The qcow2 disk is just a file; `qemu-nbd` mounts it offline.
- Network bridge taps, modifying the kernel before boot, etc.

That's `AttestedResearchTier` / SEV-SNP territory and needs hardware paygress doesn't yet have. The new design doc — `docs/plans/kvm-backend-and-isolation-tiers.md` — lays out the upgrade path: same backend, +SEV-SNP qemu flags + attestation handshake. Lands when an EPYC host is provisioned (~€30/mo Hetzner CCX13, $0.20/hr Azure DCasv5).

## How it works

**`src/kvm.rs`** (new, ~530 lines including doc-comments + tests):
- `KvmBackend` impls `ComputeBackend`.
- Per-spawn: download Ubuntu cloud image once → qcow2 overlay per-VM → cloud-init seed iso for SSH bootstrap → qemu daemonized with pidfile.
- Storage layout under `/var/lib/paygress/vm/<id>/`.
- `KvmBackend::check_kvm_available()` fails fast at provider startup if `/dev/kvm` is missing or qemu isn't on PATH — the "this host can't do KVM" surfaces *before* any consumer commits a Cashu token.

**`src/provider.rs`**:
- New `BackendType::Kvm` variant.
- `ProviderService::new` constructs the backend + runs the KVM-availability check.
- `publish_offer` derives `isolation_level` from the backend: `Kvm → DedicatedHost`; everything else → `SharedKernel`.

**`src/cli/commands/provider.rs`**: `provider start` prints "Backend: KVM/qemu" + the requirements note.

## Deliberate v1 cuts (tracked in the design doc)

1. **Killer-template Docker images don't run inside the VM.** Vanilla Ubuntu only. A follow-up PR can use cloud-init userdata to install Docker + the template.
2. **Only SSH host-port forwarding.** The qemu argv builder supports multi-port forwards, but the consumer-facing CLI surface lands with the templates-on-VMs follow-up.
3. **No qcow2 disk encryption with the consumer's key.** PR #47's LUKS-on-loop was for Docker named volumes; LUKS-inside-the-guest is a follow-up.
4. **No crash-recovery sweep for orphaned VMs.** Pidfile + process-still-alive scan lands separately.

## Tests

- **6 unit tests** in `src/kvm.rs` cover the qemu-argv builder: KVM acceleration + `cpu host`, SSH + template port forwards, id-scoped pidfile + disks, 512 MB memory floor, all paths under `VM_ROOT`, cloud-init userdata includes pwauth + password.
- The actual qemu spawn is an **acceptance test** on a KVM-enabled host (full procedure in the design doc).
- Full suite: **198 green** (was 192; +6 KVM unit tests).

## Test plan

- [x] `cargo build --release --no-default-features --bin paygress-cli` clean
- [x] `cargo test --release --all-features` 198/198
- [x] `cargo fmt --all --check` clean
- [ ] CI green
- [ ] Acceptance on a KVM-enabled host: `paygress-cli provider start --config <kvm-config>` → `paygress-cli spawn --provider <npub>` → `ssh -p <port> root@<host> 'uname -r'` returns a kernel version different from the host's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)