### PR TITLE
feat(isolation): consumer --isolation-level filter + provider --backend setup

### DIFF
--- a/src/cli/commands/batch.rs
+++ b/src/cli/commands/batch.rs
@@ -337,6 +337,7 @@ pub async fn execute(args: BatchArgs, _verbose: bool) -> Result<()> {
                 None,
                 None,
                 None,
+                None,
                 relays,
                 nostr_key,
                 timeout,

--- a/src/cli/commands/deploy.rs
+++ b/src/cli/commands/deploy.rs
@@ -291,6 +291,11 @@ pub async fn execute(args: DeployArgs, verbose: bool) -> Result<()> {
         // overrides live on `paygress-cli spawn`.
         encrypt_volume: false,
         no_encrypt_volume: false,
+        // Deploy doesn't expose --isolation-level today; consumers
+        // who need a stricter tier use `paygress-cli spawn` directly.
+        // The default (None) means deploy accepts any tier the
+        // provider offers — matching today's behavior.
+        isolation_level: None,
     };
     spawn::execute(spawn_args, verbose).await
 }

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -12,7 +12,20 @@ use indicatif::{ProgressBar, ProgressStyle};
 use super::identity::parse_relays;
 use crate::api::PaygressClient;
 use paygress::discovery::DiscoveryClient;
-use paygress::nostr::ProviderFilter;
+use paygress::nostr::{IsolationLevel, ProviderFilter};
+
+/// clap value-parser for the `--isolation-level` flag. Mirrors
+/// `IsolationLevel::from_slug` but errors with a list of valid
+/// values instead of returning `None`.
+fn parse_isolation_level(s: &str) -> Result<IsolationLevel, String> {
+    IsolationLevel::from_slug(s).ok_or_else(|| {
+        format!(
+            "unknown isolation level `{}` (expected one of: \
+             shared-kernel, dedicated-host, attested-research-tier)",
+            s
+        )
+    })
+}
 
 #[derive(Args)]
 pub struct ListArgs {
@@ -26,6 +39,16 @@ pub struct ListArgs {
     /// Filter by capability (lxc, vm)
     #[arg(long)]
     pub capability: Option<String>,
+
+    /// Minimum isolation tier the provider must offer.
+    /// `shared-kernel` (containers, weakest), `dedicated-host`
+    /// (per-VM, no co-tenants), or `attested-research-tier`
+    /// (SEV-SNP / TDX, host operator can't see guest memory).
+    /// Stricter tiers also match — e.g.
+    /// `--isolation-level dedicated-host` matches both
+    /// `dedicated-host` and `attested-research-tier` providers.
+    #[arg(long, value_parser = parse_isolation_level)]
+    pub isolation_level: Option<paygress::nostr::IsolationLevel>,
 
     /// Sort by (price, uptime, capacity, jobs)
     #[arg(long, default_value = "price")]
@@ -90,6 +113,7 @@ async fn execute_nostr_list(args: ListArgs, verbose: bool) -> Result<()> {
         min_uptime: None,
         min_memory_mb: None,
         min_cpu: None,
+        isolation_level: args.isolation_level,
     };
 
     let mut providers = client.list_providers(Some(filter)).await?;

--- a/src/cli/commands/mcp.rs
+++ b/src/cli/commands/mcp.rs
@@ -274,6 +274,7 @@ impl PaygressMcpServer {
                 min_uptime: params.min_uptime,
                 min_memory_mb: None,
                 min_cpu: None,
+                isolation_level: None,
             })
         } else {
             None
@@ -310,6 +311,7 @@ impl PaygressMcpServer {
             params.ssh_user.clone(),
             ssh_pass.clone(),
             params.template.clone(),
+            None,
             None,
             None,
             None,
@@ -409,6 +411,7 @@ impl PaygressMcpServer {
                     ssh_user.clone(),
                     ssh_pass.clone(),
                     template,
+                    None,
                     None,
                     None,
                     None,

--- a/src/cli/commands/provider.rs
+++ b/src/cli/commands/provider.rs
@@ -42,17 +42,31 @@ pub enum ProviderAction {
 
 #[derive(Args)]
 pub struct SetupArgs {
-    /// Proxmox API URL (e.g., https://192.168.1.100:8006/api2/json)
-    #[arg(long)]
-    pub proxmox_url: String,
+    /// Compute backend the provider will use to run consumer
+    /// workloads. Determines the offer's `isolation_level`:
+    ///   - `proxmox` / `lxd` / `docker` → `shared-kernel`
+    ///   - `kvm`                          → `dedicated-host` (per-VM)
+    /// Default is `proxmox` for backwards compatibility with
+    /// existing setups; new operators on bare-metal Linux usually
+    /// want `--backend kvm` (no Proxmox install needed) or
+    /// `--backend docker` (for the killer-templates path).
+    #[arg(long, default_value = "proxmox", value_parser = parse_backend)]
+    pub backend: paygress::provider::BackendType,
 
-    /// Proxmox API token ID (e.g., root@pam!paygress)
-    #[arg(long)]
-    pub token_id: String,
+    /// Proxmox API URL (e.g., https://192.168.1.100:8006/api2/json).
+    /// Required only when `--backend proxmox`.
+    #[arg(long, required_if_eq("backend", "proxmox"))]
+    pub proxmox_url: Option<String>,
 
-    /// Proxmox API token secret
-    #[arg(long)]
-    pub token_secret: String,
+    /// Proxmox API token ID (e.g., root@pam!paygress).
+    /// Required only when `--backend proxmox`.
+    #[arg(long, required_if_eq("backend", "proxmox"))]
+    pub token_id: Option<String>,
+
+    /// Proxmox API token secret.
+    /// Required only when `--backend proxmox`.
+    #[arg(long, required_if_eq("backend", "proxmox"))]
+    pub token_secret: Option<String>,
 
     /// Proxmox node name
     #[arg(long, default_value = "pve")]
@@ -231,13 +245,16 @@ async fn execute_setup(args: SetupArgs, verbose: bool) -> Result<()> {
         }
     };
 
-    // Create configuration
+    // Create configuration. proxmox_* fields are only meaningful
+    // for `backend == Proxmox`; for other backends they're stored
+    // as empty strings (the JSON keeps the same shape so rolling
+    // back to Proxmox just needs `--proxmox-url ...` re-supplied).
     let config = ProviderConfig {
-        backend_type: Default::default(),
+        backend_type: args.backend,
         public_ip,
-        proxmox_url: args.proxmox_url,
-        proxmox_token_id: args.token_id,
-        proxmox_token_secret: args.token_secret,
+        proxmox_url: args.proxmox_url.unwrap_or_default(),
+        proxmox_token_id: args.token_id.unwrap_or_default(),
+        proxmox_token_secret: args.token_secret.unwrap_or_default(),
         proxmox_node: args.node,
         proxmox_storage: args.storage,
         proxmox_template: args.template,
@@ -268,8 +285,44 @@ async fn execute_setup(args: SetupArgs, verbose: bool) -> Result<()> {
     save_config(CONFIG_PATH, &config)?;
     println!("  {} Configuration saved to {}", "✓".green(), CONFIG_PATH);
 
-    // Test Proxmox connection
+    // Per-backend startup check. Skip the Proxmox round-trip for
+    // backends that don't talk to Proxmox; for KVM, surface the
+    // /dev/kvm + qemu requirement at setup time so the operator
+    // doesn't discover it at first-spawn.
     println!();
+    match args.backend {
+        paygress::provider::BackendType::Kvm => {
+            println!("  {} Verifying KVM availability...", "⚙".yellow());
+            match paygress::kvm::KvmBackend::check_kvm_available().await {
+                Ok(version) => println!(
+                    "  {} KVM available — {} (offer publishes isolation_level=dedicated-host)",
+                    "✓".green(),
+                    version
+                ),
+                Err(e) => println!("  {} KVM unavailable: {}", "✗".red(), e),
+            }
+            return finalize_setup(&args.name);
+        }
+        paygress::provider::BackendType::Docker => {
+            println!("  {} Backend = Docker; no Proxmox check.", "⚙".yellow());
+            println!(
+                "  {} Ensure `docker` is on PATH and the service user can run it.",
+                "→".cyan()
+            );
+            return finalize_setup(&args.name);
+        }
+        paygress::provider::BackendType::LXD => {
+            println!("  {} Backend = LXD; no Proxmox check.", "⚙".yellow());
+            println!(
+                "  {} Ensure `lxc` is on PATH and the service user is in the `lxd` group.",
+                "→".cyan()
+            );
+            return finalize_setup(&args.name);
+        }
+        paygress::provider::BackendType::Proxmox => { /* fall through */ }
+    }
+
+    // Proxmox-only path: validate the API connection.
     println!("  {} Testing Proxmox connection...", "⚙".yellow());
 
     match paygress::proxmox::ProxmoxClient::new(
@@ -297,6 +350,12 @@ async fn execute_setup(args: SetupArgs, verbose: bool) -> Result<()> {
         }
     }
 
+    finalize_setup(&args.name)
+}
+
+/// Print the post-setup "Setup Complete!" banner. Extracted from
+/// `execute_setup` so per-backend early-returns share one ending.
+fn finalize_setup(provider_name: &str) -> Result<()> {
     println!();
     println!("{}", "━".repeat(50).blue());
     println!("{}", "🎉 Setup Complete!".green().bold());
@@ -304,9 +363,24 @@ async fn execute_setup(args: SetupArgs, verbose: bool) -> Result<()> {
     println!("To start your provider, run:");
     println!("  {} provider start", "paygress-cli".cyan());
     println!();
-    println!("Your provider name: {}", args.name.yellow());
-
+    println!("Your provider name: {}", provider_name.yellow());
     Ok(())
+}
+
+/// clap value-parser for `--backend`. Maps the kebab-case slug
+/// (`proxmox` / `lxd` / `docker` / `kvm`) onto the
+/// `BackendType` enum, with a friendly error listing valid values.
+fn parse_backend(s: &str) -> std::result::Result<paygress::provider::BackendType, String> {
+    match s {
+        "proxmox" => Ok(paygress::provider::BackendType::Proxmox),
+        "lxd" => Ok(paygress::provider::BackendType::LXD),
+        "docker" => Ok(paygress::provider::BackendType::Docker),
+        "kvm" => Ok(paygress::provider::BackendType::Kvm),
+        other => Err(format!(
+            "unknown backend `{}` (expected one of: proxmox, lxd, docker, kvm)",
+            other
+        )),
+    }
 }
 
 async fn execute_start(args: StartArgs, verbose: bool) -> Result<()> {

--- a/src/cli/commands/spawn.rs
+++ b/src/cli/commands/spawn.rs
@@ -139,6 +139,28 @@ pub struct SpawnArgs {
     /// encryption-related provider issue.
     #[arg(long, conflicts_with = "encrypt_volume")]
     pub no_encrypt_volume: bool,
+
+    /// Minimum isolation tier the provider must offer.
+    /// `shared-kernel` (containers, weakest), `dedicated-host`
+    /// (per-VM, no co-tenants), or `attested-research-tier`
+    /// (SEV-SNP / TDX confidential VM). Stricter tiers also match.
+    /// The CLI verifies the provider's offer meets this tier
+    /// BEFORE the Cashu token is sent — a tier mismatch fails
+    /// fast and never spends the token.
+    #[arg(long, value_parser = parse_isolation_level_arg)]
+    pub isolation_level: Option<paygress::nostr::IsolationLevel>,
+}
+
+/// clap value-parser for the `--isolation-level` flag. Mirrors the
+/// one in `list.rs` (kept local to avoid cross-command coupling).
+fn parse_isolation_level_arg(s: &str) -> Result<paygress::nostr::IsolationLevel, String> {
+    paygress::nostr::IsolationLevel::from_slug(s).ok_or_else(|| {
+        format!(
+            "unknown isolation level `{}` (expected one of: \
+             shared-kernel, dedicated-host, attested-research-tier)",
+            s
+        )
+    })
 }
 
 /// Translate the `--replication` + `--standby` CLI flags into the
@@ -339,6 +361,7 @@ pub async fn nostr_spawn_round_trip(
     primary_npub: Option<String>,
     workload_id: Option<String>,
     volume_encryption: Option<paygress::nostr::VolumeEncryption>,
+    isolation_level: Option<paygress::nostr::IsolationLevel>,
     relays: Vec<String>,
     nostr_key: String,
     timeout_secs: u64,
@@ -358,6 +381,23 @@ pub async fn nostr_spawn_round_trip(
     // spending the token rather than after.
     if !provider.specs.iter().any(|s| s.id == tier) {
         anyhow::bail!("Tier '{}' not available on this provider", tier);
+    }
+
+    // Isolation-tier pre-check: if caller demanded a minimum tier,
+    // refuse the spawn (and never spend the token) when the
+    // provider's offer doesn't meet it. The check uses
+    // `IsolationLevel::meets`, so `dedicated-host` matches both
+    // `dedicated-host` and `attested-research-tier` providers.
+    if let Some(min_iso) = isolation_level {
+        if !provider.isolation_level.meets(min_iso) {
+            anyhow::bail!(
+                "provider's isolation tier `{}` does not meet requested minimum `{}`; \
+                 try `paygress-cli list --isolation-level {}` to discover providers that do",
+                provider.isolation_level.slug(),
+                min_iso.slug(),
+                min_iso.slug(),
+            );
+        }
     }
 
     let request = EncryptedSpawnPodRequest {
@@ -506,6 +546,7 @@ async fn execute_nostr_spawn(
         args.primary_npub.clone(),
         effective_workload_id,
         volume_encryption,
+        args.isolation_level,
         relays,
         nostr_key,
         120,

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -87,6 +87,7 @@ impl DiscoveryClient {
                 total_jobs_completed: offer.total_jobs_completed,
                 last_seen,
                 is_online,
+                isolation_level: offer.isolation_level,
             };
 
             // Apply filters
@@ -108,6 +109,11 @@ impl DiscoveryClient {
                 }
                 if let Some(min_cpu) = f.min_cpu {
                     if !provider.specs.iter().any(|s| s.cpu_millicores >= min_cpu) {
+                        continue;
+                    }
+                }
+                if let Some(min_iso) = f.isolation_level {
+                    if !provider.isolation_level.meets(min_iso) {
                         continue;
                     }
                 }
@@ -388,6 +394,7 @@ mod tests {
             total_jobs_completed: 10,
             last_seen: 0,
             is_online: true,
+            isolation_level: crate::nostr::IsolationLevel::SharedKernel,
         }];
 
         let table = DiscoveryClient::format_provider_table(&providers);

--- a/src/nostr.rs
+++ b/src/nostr.rs
@@ -912,7 +912,7 @@ pub struct CapacityInfo {
 /// Provider isolation level (Unit 4 surfaces this on offers from
 /// Q1; Unit 22 will populate it with the real research-tier
 /// implementation). `#[serde(default)]` so v0 offers parse cleanly.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum IsolationLevel {
     /// Default LXC / shared-kernel container.
@@ -922,6 +922,50 @@ pub enum IsolationLevel {
     DedicatedHost,
     /// Attested AMD SEV-SNP / Intel TDX research tier (year-2 R9).
     AttestedResearchTier,
+}
+
+impl IsolationLevel {
+    /// Numeric strength ordering used for "minimum acceptable tier"
+    /// comparisons. Higher = more isolated. NOT a Deserialize hint
+    /// (the wire format is the kebab-case slug); just a helper for
+    /// the consumer's `--isolation-level` filter to decide whether
+    /// a provider's offer meets the consumer's threshold.
+    ///
+    /// SharedKernel = 0, DedicatedHost = 1, AttestedResearchTier = 2.
+    /// `meets(min)` returns true iff `self >= min` in this ordering.
+    pub fn rank(self) -> u8 {
+        match self {
+            Self::SharedKernel => 0,
+            Self::DedicatedHost => 1,
+            Self::AttestedResearchTier => 2,
+        }
+    }
+
+    /// True iff this offer's isolation tier is at least as strong
+    /// as `min`. Used by the consumer's offer filter.
+    pub fn meets(self, min: IsolationLevel) -> bool {
+        self.rank() >= min.rank()
+    }
+
+    /// Parse the kebab-case slug used on the CLI and the wire.
+    pub fn from_slug(s: &str) -> Option<Self> {
+        match s {
+            "shared-kernel" => Some(Self::SharedKernel),
+            "dedicated-host" => Some(Self::DedicatedHost),
+            "attested-research-tier" => Some(Self::AttestedResearchTier),
+            _ => None,
+        }
+    }
+
+    /// Inverse of `from_slug` — for displaying a provider's tier
+    /// to the consumer.
+    pub fn slug(self) -> &'static str {
+        match self {
+            Self::SharedKernel => "shared-kernel",
+            Self::DedicatedHost => "dedicated-host",
+            Self::AttestedResearchTier => "attested-research-tier",
+        }
+    }
 }
 
 fn default_schema_version() -> u8 {
@@ -1026,6 +1070,11 @@ pub struct ProviderInfo {
     pub total_jobs_completed: u64,
     pub last_seen: u64, // Timestamp of last heartbeat
     pub is_online: bool,
+    /// Isolation tier the provider promises (mirrored from
+    /// `ProviderOfferContent.isolation_level`). Consumers filtering
+    /// by `--isolation-level` match on this. Defaults to
+    /// `SharedKernel` for v0 offers (no field on the wire).
+    pub isolation_level: IsolationLevel,
 }
 
 /// Filter for querying providers
@@ -1035,6 +1084,10 @@ pub struct ProviderFilter {
     pub min_uptime: Option<f32>,
     pub min_memory_mb: Option<u64>,
     pub min_cpu: Option<u64>,
+    /// Minimum acceptable isolation tier. `Some(DedicatedHost)`
+    /// matches `DedicatedHost` and `AttestedResearchTier` providers
+    /// (anything stricter is also acceptable). `None` = no filter.
+    pub isolation_level: Option<IsolationLevel>,
 }
 
 impl NostrRelaySubscriber {
@@ -1399,4 +1452,50 @@ pub struct StatusResponseContent {
     pub ssh_host: String,
     pub ssh_port: u16,
     pub ssh_username: String,
+}
+
+#[cfg(test)]
+mod isolation_level_tests {
+    use super::IsolationLevel;
+
+    #[test]
+    fn rank_orders_isolation_strength() {
+        assert!(IsolationLevel::SharedKernel.rank() < IsolationLevel::DedicatedHost.rank());
+        assert!(IsolationLevel::DedicatedHost.rank() < IsolationLevel::AttestedResearchTier.rank());
+    }
+
+    #[test]
+    fn meets_accepts_equal_or_stricter_tiers() {
+        // SharedKernel as the minimum: any tier qualifies.
+        assert!(IsolationLevel::SharedKernel.meets(IsolationLevel::SharedKernel));
+        assert!(IsolationLevel::DedicatedHost.meets(IsolationLevel::SharedKernel));
+        assert!(IsolationLevel::AttestedResearchTier.meets(IsolationLevel::SharedKernel));
+        // DedicatedHost as the minimum: SharedKernel does NOT qualify.
+        assert!(!IsolationLevel::SharedKernel.meets(IsolationLevel::DedicatedHost));
+        assert!(IsolationLevel::DedicatedHost.meets(IsolationLevel::DedicatedHost));
+        assert!(IsolationLevel::AttestedResearchTier.meets(IsolationLevel::DedicatedHost));
+        // AttestedResearchTier as the minimum: only it qualifies.
+        assert!(!IsolationLevel::SharedKernel.meets(IsolationLevel::AttestedResearchTier));
+        assert!(!IsolationLevel::DedicatedHost.meets(IsolationLevel::AttestedResearchTier));
+        assert!(IsolationLevel::AttestedResearchTier.meets(IsolationLevel::AttestedResearchTier));
+    }
+
+    #[test]
+    fn slug_round_trips() {
+        for level in [
+            IsolationLevel::SharedKernel,
+            IsolationLevel::DedicatedHost,
+            IsolationLevel::AttestedResearchTier,
+        ] {
+            assert_eq!(IsolationLevel::from_slug(level.slug()), Some(level));
+        }
+    }
+
+    #[test]
+    fn from_slug_rejects_unknown() {
+        assert!(IsolationLevel::from_slug("paranoid-mode").is_none());
+        assert!(IsolationLevel::from_slug("").is_none());
+        // Underscore form (not what we serialize) — must NOT be accepted.
+        assert!(IsolationLevel::from_slug("dedicated_host").is_none());
+    }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -32,7 +32,7 @@ use crate::nostr::{
 use crate::proxmox::{ProxmoxBackend, ProxmoxClient};
 use crate::templates::{TemplateDefinition, TemplateName};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BackendType {
     Proxmox,
     LXD,


### PR DESCRIPTION
## Summary

Stacks on **#49** (KVM backend). Wires up the consumer-side and operator-side surface that PR #49's tier-aware backend introduced.

Defaults are unchanged (`SharedKernel` via Docker); the new flags let consumers filter for stricter tiers and operators pick a backend at setup time without dummy Proxmox creds.

## Consumer side

\`\`\`bash
# Discover only providers that promise per-VM isolation or stronger:
paygress-cli list --isolation-level dedicated-host

# Spawn against a specific provider, but fail-fast (without spending
# the Cashu token) if the provider's offer doesn't meet the tier:
paygress-cli spawn --provider <npub> --token <cashu> \
    --isolation-level dedicated-host
\`\`\`

The check uses `IsolationLevel::meets`, so `--isolation-level dedicated-host` matches both `dedicated-host` and `attested-research-tier` providers — stricter offers always satisfy a more permissive consumer ask.

**`paygress::nostr::IsolationLevel`** picks up:
- `Copy` derive (was Clone-only)
- `rank()` — strength ordering (`SharedKernel < DedicatedHost < AttestedResearchTier`)
- `meets(min)` — \"this offer's tier is at least as strong as the consumer's threshold\"
- `slug()` / `from_slug()` — kebab-case (de)serialization for CLI + wire format

**`ProviderInfo`** gains `isolation_level`, mirrored from `ProviderOfferContent` during discovery. v0 offers (no field on the wire) default to `SharedKernel` via serde default.

**`ProviderFilter`** gains `isolation_level: Option<IsolationLevel>`; `discovery::list_providers` short-circuits providers whose tier doesn't `meet` the requested minimum.

## Operator side

\`\`\`bash
# Today (Proxmox, default — unchanged):
paygress-cli provider setup --proxmox-url ... --token-id ... --token-secret ... --name MyNode

# New: KVM backend, no Proxmox creds needed
paygress-cli provider setup --backend kvm --name MyNode
# → at setup time: verifies /dev/kvm + qemu-system-x86_64 are present
# → at runtime: offer publishes isolation_level=dedicated-host

# New: Docker/LXD also drop Proxmox-creds requirement
paygress-cli provider setup --backend docker --name MyNode
paygress-cli provider setup --backend lxd --name MyNode
\`\`\`

Per-backend startup checks happen at **setup time, not first-spawn time** — operator learns about missing `/dev/kvm` or qemu install at `provider setup --backend kvm`, not when a paying consumer's request hits the wire.

`--proxmox-url` / `--token-id` / `--token-secret` use clap `required_if_eq(\"backend\", \"proxmox\")` so they're only required when needed.

## What's NOT in scope (deliberate)

- **`paygress-cli list info <npub>`** doesn't yet print the provider's tier in the table. Cosmetic; lands separately if anyone notices.
- **MCP-server tools** don't expose the `--isolation-level` flag. Same shape as how MCP doesn't expose --replication today; the agent path can pass `None` (no filter) safely.
- **Batch coordinator** doesn't expose it either; same reason.
- **Deploy CLI** doesn't expose it; consumers who need a strict tier use `paygress-cli spawn` directly.

All three callers were updated to pass `None` to `nostr_spawn_round_trip`'s new parameter.

## Tests

- 4 new tests for `IsolationLevel` (rank ordering, meets-or-stricter, slug round-trip, unknown-slug rejection).
- `mcp` / `batch` / `deploy` callers updated for the new `nostr_spawn_round_trip` parameter + the new `ProviderFilter` field.
- Discovery test fixture populated with the new field.
- Full suite: **206 green** (was 198 → +4 IsolationLevel tests + 4 re-counted across modules).

## Test plan

- [x] `cargo build --release --no-default-features --bin paygress-cli` clean
- [x] `cargo test --release --all-features` 206/206
- [x] `cargo fmt --all --check` clean
- [ ] CI green
- [ ] On a KVM-enabled host: `paygress-cli provider setup --backend kvm --name TestKvm` succeeds, `provider start` publishes an offer with `isolation_level=dedicated-host`, consumer's `paygress-cli list --isolation-level dedicated-host` finds only that offer (or any other dedicated-host providers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)