### PR TITLE
feat(isolation): show tier in list output + isolation-level for MCP/batch

### DIFF
--- a/src/cli/commands/batch.rs
+++ b/src/cli/commands/batch.rs
@@ -102,6 +102,28 @@ pub struct BatchArgs {
     /// CLI's default relay list.
     #[arg(long)]
     pub relays: Option<String>,
+
+    /// Minimum isolation tier the provider must offer. Stricter
+    /// tiers also match. One of: `shared-kernel`, `dedicated-host`,
+    /// `attested-research-tier`. Applied uniformly to every shard
+    /// (they all spawn against the same `--provider`, so the check
+    /// is per-batch, not per-shard). The check runs before any
+    /// Cashu token is sent.
+    #[arg(long, value_parser = parse_isolation_level_arg)]
+    pub isolation_level: Option<paygress::nostr::IsolationLevel>,
+}
+
+/// clap value-parser for `--isolation-level`. Local to batch to
+/// avoid cross-command coupling; kept symmetric with the helpers in
+/// `list.rs` and `spawn.rs`.
+fn parse_isolation_level_arg(s: &str) -> Result<paygress::nostr::IsolationLevel, String> {
+    paygress::nostr::IsolationLevel::from_slug(s).ok_or_else(|| {
+        format!(
+            "unknown isolation level `{}` (expected one of: \
+             shared-kernel, dedicated-host, attested-research-tier)",
+            s
+        )
+    })
 }
 
 /// Per-shard outcome that lands in the JSON manifest. Fields are a
@@ -323,6 +345,7 @@ pub async fn execute(args: BatchArgs, _verbose: bool) -> Result<()> {
         let timeout = args.timeout_secs;
         let ssh_user = "user".to_string();
         let ssh_pass = generate_password(16);
+        let iso = args.isolation_level;
 
         let handle = tokio::spawn(async move {
             let outcome = nostr_spawn_round_trip(
@@ -337,7 +360,7 @@ pub async fn execute(args: BatchArgs, _verbose: bool) -> Result<()> {
                 None,
                 None,
                 None,
-                None,
+                iso,
                 relays,
                 nostr_key,
                 timeout,
@@ -476,6 +499,7 @@ mod tests {
             image: "ubuntu:22.04".to_string(),
             nostr_key: None,
             relays: None,
+            isolation_level: None,
         }
     }
 
@@ -493,6 +517,7 @@ mod tests {
             image: "ubuntu:22.04".to_string(),
             nostr_key: None,
             relays: None,
+            isolation_level: None,
         }
     }
 
@@ -510,6 +535,7 @@ mod tests {
             image: "ubuntu:22.04".to_string(),
             nostr_key: None,
             relays: None,
+            isolation_level: None,
         }
     }
 

--- a/src/cli/commands/mcp.rs
+++ b/src/cli/commands/mcp.rs
@@ -117,6 +117,15 @@ pub struct SpawnParams {
     /// Per-spawn timeout in seconds.
     #[serde(default = "default_timeout_secs")]
     pub timeout_secs: u64,
+    /// Minimum isolation tier the provider must offer. Stricter
+    /// tiers also match. One of:
+    ///   - "shared-kernel" (Docker / LXC; weakest)
+    ///   - "dedicated-host" (per-VM; no co-tenants)
+    ///   - "attested-research-tier" (SEV-SNP / TDX confidential VM)
+    /// When unset, no filter is applied. The check runs before the
+    /// Cashu token is sent — a tier mismatch fails fast.
+    #[serde(default)]
+    pub isolation_level: Option<String>,
 }
 
 fn default_tier() -> String {
@@ -156,10 +165,33 @@ pub struct BatchParams {
     /// Per-shard timeout in seconds.
     #[serde(default = "default_timeout_secs")]
     pub timeout_secs: u64,
+    /// Minimum isolation tier the provider must offer (same enum
+    /// as `SpawnParams.isolation_level`). Applied to every shard.
+    #[serde(default)]
+    pub isolation_level: Option<String>,
 }
 
 fn default_batch_template() -> String {
     "agent-sandbox".to_string()
+}
+
+/// Resolve the optional MCP `isolation_level` string into the
+/// internal enum. Returns an MCP error if the slug is not one of
+/// the three valid values, so an agent-driven caller learns about
+/// the typo immediately rather than after the spawn round-trip.
+fn parse_iso_param(s: Option<&str>) -> Result<Option<paygress::nostr::IsolationLevel>, McpError> {
+    match s {
+        None => Ok(None),
+        Some(slug) => paygress::nostr::IsolationLevel::from_slug(slug).map(Some).ok_or_else(|| {
+            McpError::invalid_params(
+                format!(
+                    "isolation_level: unknown value `{}` (expected: shared-kernel, dedicated-host, attested-research-tier)",
+                    slug
+                ),
+                None,
+            )
+        }),
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -302,6 +334,7 @@ impl PaygressMcpServer {
             .ssh_pass
             .clone()
             .unwrap_or_else(|| generate_password(16));
+        let iso = parse_iso_param(params.isolation_level.as_deref())?;
 
         let outcome = nostr_spawn_round_trip(
             &params.provider,
@@ -315,7 +348,7 @@ impl PaygressMcpServer {
             None,
             None,
             None,
-            None,
+            iso,
             relays,
             nostr_key,
             params.timeout_secs,
@@ -379,6 +412,10 @@ impl PaygressMcpServer {
             image: default_image(),
             nostr_key: self.nostr_key.clone(),
             relays: self.relays_override.clone(),
+            // The MCP-side `iso` is parsed below and applied per
+            // shard directly to nostr_spawn_round_trip; we don't
+            // need batch::materialize_tokens to know about it.
+            isolation_level: None,
         };
         let tokens = batch::materialize_tokens(&cli_args)
             .await
@@ -387,6 +424,7 @@ impl PaygressMcpServer {
 
         let relays = self.resolve_relays();
         let nostr_key = self.resolve_nostr_key()?;
+        let iso = parse_iso_param(params.isolation_level.as_deref())?;
 
         // Concurrent spawn fan-out (same shape as batch::execute, but
         // collected into a JSON manifest rather than written to disk).
@@ -401,6 +439,7 @@ impl PaygressMcpServer {
             let timeout = params.timeout_secs;
             let ssh_user = "user".to_string();
             let ssh_pass = generate_password(16);
+            let iso_per_shard = iso;
 
             handles.push(tokio::spawn(async move {
                 let outcome = nostr_spawn_round_trip(
@@ -415,7 +454,7 @@ impl PaygressMcpServer {
                     None,
                     None,
                     None,
-                    None,
+                    iso_per_shard,
                     relays,
                     nostr_key,
                     timeout,

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -226,11 +226,16 @@ impl DiscoveryClient {
 
         let mut output = String::new();
 
+        // Replaced the historically-uniform `LXC/VM` column with
+        // `TIER` (the offer's isolation level) — every provider
+        // today reports `lxc/vm`, so the old column was decorative.
+        // `TIER` is the only column that distinguishes a Docker
+        // provider from a per-VM KVM provider in the listing.
         writeln!(&mut output, "┌──────────────────────────────────────────────────────────────────────────────────────────────────────┐").unwrap();
         writeln!(
             &mut output,
             "│ {:^16} │ {:^18} │ {:^10} │ {:^8} │ {:^8} │ {:^10} │ {:^6} │",
-            "ID", "PROVIDER", "LOCATION", "UPTIME", "CHEAPEST", "LXC/VM", "ONLINE"
+            "ID", "PROVIDER", "LOCATION", "UPTIME", "CHEAPEST", "TIER", "ONLINE"
         )
         .unwrap();
         writeln!(&mut output, "├──────────────────────────────────────────────────────────────────────────────────────────────────────┤").unwrap();
@@ -245,7 +250,13 @@ impl DiscoveryClient {
                 .min()
                 .map(|r| format!("{}m/s", r))
                 .unwrap_or_else(|| "-".to_string());
-            let capabilities = p.capabilities.join("/");
+            // Compact tier label that fits the 10-char column.
+            // `attested-research-tier` is too long; abbreviate.
+            let tier = match p.isolation_level {
+                crate::nostr::IsolationLevel::SharedKernel => "shared",
+                crate::nostr::IsolationLevel::DedicatedHost => "dedicated",
+                crate::nostr::IsolationLevel::AttestedResearchTier => "attested",
+            };
             let online = if p.is_online { "✓" } else { "✗" };
 
             writeln!(
@@ -256,7 +267,7 @@ impl DiscoveryClient {
                 truncate_str(location, 10),
                 p.uptime_percent,
                 cheapest,
-                capabilities,
+                tier,
                 online
             )
             .unwrap();
@@ -317,6 +328,26 @@ impl DiscoveryClient {
             &mut output,
             "│ Supports:   {}",
             provider.capabilities.join(", ")
+        )
+        .unwrap();
+        // Full slug here (vs the abbreviated form in the table).
+        // Annotated so a reader who's only just discovering the
+        // tier system understands what each label means without
+        // bouncing to the docs.
+        let iso_annotation = match provider.isolation_level {
+            crate::nostr::IsolationLevel::SharedKernel => " (containers; co-tenant boundary only)",
+            crate::nostr::IsolationLevel::DedicatedHost => {
+                " (per-VM; no co-tenants, but operator can read guest)"
+            }
+            crate::nostr::IsolationLevel::AttestedResearchTier => {
+                " (SEV-SNP / TDX; operator cannot read guest memory)"
+            }
+        };
+        writeln!(
+            &mut output,
+            "│ Isolation:  {}{}",
+            provider.isolation_level.slug(),
+            iso_annotation
         )
         .unwrap();
         writeln!(


### PR DESCRIPTION
## Summary

Two small follow-ups on PR #50, both purely additive surface for things the underlying machinery already supports.

## list output

**Table view**: replaces the historically-uniform `LXC/VM` column with `TIER`, abbreviating each offer's isolation level so the consumer can spot per-VM providers at a glance. Every offer today reports `lxc/vm` for capabilities — the old column was decorative; the new one is actually informative.

\`\`\`
│        ID        │      PROVIDER      │  LOCATION  │  UPTIME  │ CHEAPEST │   TIER     │ ONLINE │
│ e028b2811fa8e7   │ TestNode           │  Unknown   │  100.0% │    50m/s │   shared   │   ✓    │
│ <kvm-provider>   │ HetznerKvm         │  EU-Helsi  │  100.0% │    80m/s │ dedicated  │   ✓    │
\`\`\`

**`list info` detail view**: adds an `Isolation:` row with the full slug + short annotation:

\`\`\`
│ Isolation:  dedicated-host (per-VM; no co-tenants, but operator can read guest)
\`\`\`

The annotation mirrors the `IsolationLevel` doc-comments so a reader new to the tier system understands the threat-model boundary without bouncing to the design doc.

## MCP / batch flags

**MCP tools** (`spawn_workload`, `batch_spawn`) get an `isolation_level: Option<String>` parameter on `SpawnParams` / `BatchParams`. Validated server-side via `parse_iso_param` which returns `McpError::invalid_params` on a bad slug — agent-driven callers see the typo immediately rather than after the spawn round-trip.

**`paygress-cli batch`** gets `--isolation-level <tier>`, plumbed through to `nostr_spawn_round_trip` per shard. Each shard's spawn does the same fail-fast check `paygress-cli spawn` does. Per-shard rather than per-batch because the existing pipeline puts the check inside the round-trip helper — the few extra Nostr queries are cheap and keep `nostr_spawn_round_trip` as the single source of truth for pre-flight.

## Tests

- Existing `IsolationLevel` unit tests cover the slug parser (PR #50 added them); the new CLI/MCP entry points use the same `from_slug`.
- `BatchArgs` test fixtures updated for the new field.
- Full suite: **206 green** (unchanged; this PR only adds CLI/MCP surface, no new unit-testable logic).

## Test plan

- [x] `cargo build --release --no-default-features --bin paygress-cli` clean
- [x] `cargo test --release --all-features` 206/206
- [x] `cargo fmt --all --check` clean
- [ ] CI green
- [ ] On the VPS: `paygress-cli list` shows `TIER` column populated with `shared` for all current providers (none are KVM yet); `paygress-cli list info <npub>` shows the Isolation row.
- [ ] On the VPS: `paygress-cli batch --provider <npub> --tokens ... --isolation-level dedicated-host` fails fast for every shard before spending any tokens (since today's providers are all SharedKernel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)