### PR TITLE
feat(privacy): LUKS-on-loop encrypted data volumes (Phase 2) [replay of #47]

### DIFF
--- a/examples/spawn_template_local.rs
+++ b/examples/spawn_template_local.rs
@@ -80,6 +80,7 @@ async fn main() -> anyhow::Result<()> {
         template_env,
         extra_runtime_args,
         data_path: def.data_path.map(|p| p.to_string()),
+        volume_encryption_key: None,
     };
 
     let docker_id = backend.create_container(&cfg).await?;

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -61,6 +61,23 @@ pub struct ContainerConfig {
     /// Docker backend mounts a vmid-scoped volume there.
     /// `None` = stateless (no volume created).
     pub data_path: Option<String>,
+
+    /// Optional 32-byte LUKS key for the persistent data volume.
+    /// When set (Phase 2 of consumer-encrypted-volumes), the
+    /// `DockerBackend` creates a LUKS-on-loop file instead of a
+    /// plain Docker named volume; the key is fed to `cryptsetup
+    /// luksFormat`/`luksOpen` over stdin and never persisted to
+    /// disk. On `delete_container` the LUKS header is erased
+    /// (`cryptsetup luksErase`) so the keyslots are unrecoverable
+    /// even if the operator forensically extracts the underlying
+    /// file.
+    ///
+    /// Provider populates this from
+    /// `EncryptedSpawnPodRequest.volume_encryption.decoded_key()`
+    /// when present; `None` means a plain volume (today's default).
+    /// `data_path: None` makes this field a no-op (stateless
+    /// workloads have nothing to encrypt).
+    pub volume_encryption_key: Option<[u8; 32]>,
 }
 
 #[async_trait]

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -29,6 +29,7 @@ use async_trait::async_trait;
 use tokio::process::Command;
 
 use crate::compute::{ComputeBackend, ContainerConfig, NodeStatus};
+use crate::luks::{create_encrypted_volume, destroy_encrypted_volume};
 
 /// Docker backend. Stateless wrapper around the `docker` CLI.
 pub struct DockerBackend {
@@ -140,10 +141,29 @@ impl ComputeBackend for DockerBackend {
         }
 
         // Persistent state volume (vmid-scoped so two instances of
-        // the same template don't share state).
+        // the same template don't share state). Two paths:
+        //   - encrypted: provision a LUKS-on-loop file, mount its
+        //     ext4 on the host, bind-mount the mountpoint into the
+        //     container at `data_path`. Host operator's
+        //     post-eviction `tar` reveals only ciphertext.
+        //   - plain: use a Docker named volume (the historical
+        //     default; host operator can `tar` /var/lib/docker/...).
         if let Some(path) = &config.data_path {
-            args.push("-v".into());
-            args.push(format!("paygress-{}-data:{}", config.id, path));
+            match config.volume_encryption_key.as_ref() {
+                Some(key) => {
+                    let vol = create_encrypted_volume(config.id, config.storage_gb, key)
+                        .await
+                        .with_context(|| {
+                            format!("create LUKS-encrypted volume for id={}", config.id)
+                        })?;
+                    args.push("-v".into());
+                    args.push(format!("{}:{}", vol.mount_path.display(), path));
+                }
+                None => {
+                    args.push("-v".into());
+                    args.push(format!("paygress-{}-data:{}", config.id, path));
+                }
+            }
         }
 
         // Image must be the last positional arg so docker treats
@@ -187,10 +207,27 @@ impl ComputeBackend for DockerBackend {
     async fn delete_container(&self, id: u32) -> Result<()> {
         let name = Self::name_for(id);
         let _ = self.docker(&["rm", "-f", &name]).await;
-        // Best-effort: also remove the per-vmid data volume so a
+        // Best-effort: also remove BOTH possible volume backings so a
         // re-spawn doesn't inherit stale state.
+        //   1. The Docker named volume (used when volume_encryption_key
+        //      is None — historical default path).
+        //   2. The LUKS-on-loop volume (used when the consumer set
+        //      --encrypt-volume). Idempotent: the destroy helper
+        //      treats "no LUKS file at the expected id" as a no-op.
+        //      luksErase inside destroy is the load-bearing step —
+        //      it overwrites the LUKS header so the keyslots are
+        //      unrecoverable even if the operator extracted the
+        //      file before this ran.
         let volume = format!("paygress-{}-data", id);
         let _ = self.docker(&["volume", "rm", "-f", &volume]).await;
+        if let Err(e) = destroy_encrypted_volume(id).await {
+            // Never propagate: cleanup_loop relies on this being
+            // best-effort. A leaked mapper entry (e.g. provider
+            // process killed mid-cleanup) gets re-cleaned on the
+            // next delete attempt at the same id, since the helper
+            // is idempotent.
+            tracing::warn!("destroy_encrypted_volume(id={}) non-fatal: {}", id, e);
+        }
         Ok(())
     }
 
@@ -258,6 +295,7 @@ mod tests {
             },
             extra_runtime_args: vec!["--ulimit".to_string(), "nofile=1024:1024".to_string()],
             data_path: Some("/var/data".to_string()),
+            volume_encryption_key: None,
         };
 
         // Mirror the logic in `create_container` for assertion.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod volume_encryption;
 pub mod compute;
 pub mod discovery;
 pub mod docker;
+pub mod luks;
 pub mod lxd;
 pub mod provider;
 pub mod proxmox;

--- a/src/luks.rs
+++ b/src/luks.rs
@@ -1,0 +1,427 @@
+// LUKS-on-loop helpers for consumer-encrypted persistent volumes.
+//
+// Phase 2 of the volume-encryption work. Phase 1 (PR #46) shipped the
+// wire format + KDF; this module is what actually encrypts the bytes
+// on disk so the host operator's post-eviction `tar` reveals only
+// ciphertext.
+//
+// Layout on the host
+// ------------------
+// /var/lib/paygress/volumes/<id>.luks   — sparse file, LUKS2 header + payload
+// /dev/mapper/paygress-<id>-luks        — kernel device-mapper alias (after luksOpen)
+// /var/lib/paygress/mounts/<id>/        — ext4 mountpoint (the `-v` bind source)
+//
+// Lifecycle
+// ---------
+// `create_encrypted_volume` does the full create-format-open-mkfs-mount
+// dance, returning a handle whose `mount_path` the docker backend
+// bind-mounts into the container. `destroy_encrypted_volume` is the
+// inverse: umount, luksClose, luksErase (overwrites all keyslots so
+// the file's ciphertext is unrecoverable even by the host operator
+// who held the disk image), then rm.
+//
+// Idempotency
+// -----------
+// Both creation and destruction are best-effort idempotent:
+//   - create rolls back any partial state on failure (so a half-
+//     formatted file doesn't trap a future spawn at the same id),
+//   - destroy never errors on "not present" — a half-leaked mapper
+//     entry from a crashed previous run gets cleaned up on the next
+//     `delete_container`.
+//
+// Why shell-out to cryptsetup
+// ---------------------------
+// libcryptsetup-rs exists, but it links against libcryptsetup (the
+// system C library) and hauls a large unsafe surface into the
+// process. Shelling out to `/sbin/cryptsetup` keeps the LUKS code
+// path entirely in a child process — easier to audit, easier to
+// strace, and matches how every other paygress subprocess (docker,
+// nginx) is invoked. Performance is irrelevant: we exec cryptsetup
+// twice per workload lifetime (create + destroy).
+//
+// Threat model recap (mirrors the wire-format doc on
+// `nostr::VolumeEncryption`):
+//   - Defends: post-eviction disk forensics, lazy host-operator
+//     backups, co-tenant attacks on shared storage, cold-disk
+//     seizure.
+//   - Does NOT defend: live host kernel reading /proc/<pid>/mem or
+//     extracting the LUKS key from the kernel keyring while the
+//     workload runs. That requires hardware confidential VMs
+//     (SEV-SNP / TDX), gated behind the `attested-research-tier`
+//     `IsolationLevel`.
+//   - The key is fed to `cryptsetup` via stdin (key-file=-) so it
+//     never appears on the command line (where `ps` would leak it).
+//     Provider holds the key only in memory, dropped when
+//     `ContainerConfig` goes out of scope.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use anyhow::{Context, Result};
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+use tracing::{debug, info, warn};
+
+/// Root directory for paygress-managed encrypted volumes. Two
+/// subdirectories live here:
+/// - `volumes/<id>.luks` — sparse files holding LUKS2 containers.
+/// - `mounts/<id>/`     — ext4 mountpoints bind-mounted into the
+///                        container at `data_path`.
+const VOLUME_ROOT: &str = "/var/lib/paygress";
+
+/// Kernel device-mapper name for a workload's open LUKS volume.
+/// Stable per `id` so cleanup can find it after a provider crash.
+fn mapper_name(id: u32) -> String {
+    format!("paygress-{}-luks", id)
+}
+
+/// Sparse file backing the LUKS container.
+fn image_path(id: u32) -> PathBuf {
+    PathBuf::from(VOLUME_ROOT)
+        .join("volumes")
+        .join(format!("{}.luks", id))
+}
+
+/// Mountpoint where the open LUKS volume's ext4 lives.
+fn mount_path(id: u32) -> PathBuf {
+    PathBuf::from(VOLUME_ROOT)
+        .join("mounts")
+        .join(id.to_string())
+}
+
+/// Fully-resolved /dev/mapper path (what `mount` and Docker bind
+/// mounts care about).
+fn mapper_device(id: u32) -> PathBuf {
+    PathBuf::from("/dev/mapper").join(mapper_name(id))
+}
+
+/// Created + open + mounted handle to an encrypted volume. The
+/// `mount_path` is what the Docker backend bind-mounts at
+/// `data_path` inside the container. Drop semantics: do NOT do
+/// anything on drop — destruction is explicit via
+/// `destroy_encrypted_volume`, which the docker backend calls from
+/// `delete_container`. (Doing it on drop would risk
+/// double-destruction on retry paths.)
+#[derive(Debug, Clone)]
+pub struct EncryptedVolume {
+    pub id: u32,
+    pub mount_path: PathBuf,
+}
+
+/// Verify cryptsetup is on PATH. Provider should call this at
+/// startup if any template it serves has `data_path: Some(_)` and
+/// the operator has not opted out of consumer-encrypted volumes.
+/// Returns the version string so the operator can log what they
+/// got.
+pub async fn check_cryptsetup_available() -> Result<String> {
+    let out = Command::new("cryptsetup")
+        .arg("--version")
+        .output()
+        .await
+        .context(
+            "cryptsetup binary not found on PATH; install cryptsetup or disable encrypted-volume support",
+        )?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "cryptsetup --version returned non-zero: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Create + format + open + mount a LUKS-encrypted volume for the
+/// given workload id. Returns the mount path the caller should bind
+/// into the container.
+///
+/// On failure, attempts to roll back any partial state (close mapper,
+/// rm sparse file) so a retry at the same id starts clean.
+pub async fn create_encrypted_volume(
+    id: u32,
+    size_gb: u32,
+    key: &[u8; 32],
+) -> Result<EncryptedVolume> {
+    let img = image_path(id);
+    let mnt = mount_path(id);
+    let mapper = mapper_device(id);
+    let mapper_n = mapper_name(id);
+
+    info!(
+        "Creating LUKS-encrypted data volume: id={} size={}G image={}",
+        id,
+        size_gb,
+        img.display()
+    );
+
+    // 1. mkdir -p the parent directories. Both volumes/ and mounts/
+    //    must exist before the next steps; they survive across
+    //    spawns (best-effort once-per-host).
+    tokio::fs::create_dir_all(img.parent().unwrap())
+        .await
+        .context("create volumes/ directory")?;
+    tokio::fs::create_dir_all(&mnt)
+        .await
+        .context("create mountpoint directory")?;
+
+    // 2. Truncate to size. Sparse — only consumes disk on write.
+    //    `truncate -s` is portable across the GNU coreutils on
+    //    every Linux paygress runs on.
+    let bytes = (size_gb as u64) * 1024 * 1024 * 1024;
+    let img_str = img.to_string_lossy().to_string();
+    let trunc = Command::new("truncate")
+        .args(["-s", &bytes.to_string(), &img_str])
+        .output()
+        .await
+        .context("invoke truncate")?;
+    if !trunc.status.success() {
+        anyhow::bail!(
+            "truncate failed: {}",
+            String::from_utf8_lossy(&trunc.stderr)
+        );
+    }
+
+    // 3. luksFormat with the consumer key on stdin (--key-file=-).
+    //    --batch-mode skips the interactive "are you sure" prompt;
+    //    --type luks2 picks the modern header format with proper
+    //    PBKDF2 + AEAD; defaults are fine for AES-XTS-Plain64.
+    if let Err(e) = run_with_key_stdin(
+        "cryptsetup",
+        &[
+            "luksFormat",
+            "--type",
+            "luks2",
+            "--batch-mode",
+            "--key-file=-",
+            &img_str,
+        ],
+        key,
+    )
+    .await
+    {
+        // Roll back: the truncate-d file is unusable junk. Don't
+        // leave it behind.
+        let _ = tokio::fs::remove_file(&img).await;
+        return Err(e.context("cryptsetup luksFormat"));
+    }
+
+    // 4. luksOpen → /dev/mapper/paygress-<id>-luks. Same key on
+    //    stdin. After this the kernel device-mapper holds the key
+    //    in keyring memory (visible to root via `dmsetup info`,
+    //    which is exactly the threat-model boundary we documented).
+    if let Err(e) = run_with_key_stdin(
+        "cryptsetup",
+        &["luksOpen", "--key-file=-", &img_str, &mapper_n],
+        key,
+    )
+    .await
+    {
+        let _ = tokio::fs::remove_file(&img).await;
+        return Err(e.context("cryptsetup luksOpen"));
+    }
+
+    // 5. mkfs.ext4 on the mapper device. -F forces over any stale
+    //    signature (a re-spawn at the same id with a new key would
+    //    otherwise see leftover ext4 magic from a prior tenancy and
+    //    refuse to reformat).
+    let mapper_str = mapper.to_string_lossy().to_string();
+    let mkfs = Command::new("mkfs.ext4")
+        .args(["-F", &mapper_str])
+        .output()
+        .await
+        .context("invoke mkfs.ext4")?;
+    if !mkfs.status.success() {
+        // Roll back: close the mapper, then drop the file.
+        let _ = run("cryptsetup", &["luksClose", &mapper_n]).await;
+        let _ = tokio::fs::remove_file(&img).await;
+        anyhow::bail!(
+            "mkfs.ext4 failed: {}",
+            String::from_utf8_lossy(&mkfs.stderr)
+        );
+    }
+
+    // 6. mount to /var/lib/paygress/mounts/<id>. The Docker backend
+    //    bind-mounts this path at the template's `data_path`.
+    let mnt_str = mnt.to_string_lossy().to_string();
+    let mount = Command::new("mount")
+        .args([&mapper_str, &mnt_str])
+        .output()
+        .await
+        .context("invoke mount")?;
+    if !mount.status.success() {
+        let _ = run("cryptsetup", &["luksClose", &mapper_n]).await;
+        let _ = tokio::fs::remove_file(&img).await;
+        anyhow::bail!("mount failed: {}", String::from_utf8_lossy(&mount.stderr));
+    }
+
+    info!(
+        "LUKS volume id={} ready: mounted at {} (mapper {})",
+        id,
+        mnt.display(),
+        mapper.display()
+    );
+    Ok(EncryptedVolume {
+        id,
+        mount_path: mnt,
+    })
+}
+
+/// Tear down everything `create_encrypted_volume` set up. Idempotent
+/// — never errors on "already gone". Order matters:
+/// 1. umount the ext4 (releases the kernel block device handle)
+/// 2. luksClose (releases the mapper entry + the LUKS key from
+///    keyring memory)
+/// 3. luksErase (overwrites all keyslots → the underlying file's
+///    ciphertext is unrecoverable, even if the operator copied the
+///    file before this step ran)
+/// 4. rm the sparse file (free disk space; defense-in-depth even
+///    after luksErase)
+/// 5. rmdir the mountpoint (cosmetic; keeps /var/lib/paygress/mounts
+///    tidy)
+pub async fn destroy_encrypted_volume(id: u32) -> Result<()> {
+    let img = image_path(id);
+    let mnt = mount_path(id);
+    let mapper_n = mapper_name(id);
+    let img_str = img.to_string_lossy().to_string();
+    let mnt_str = mnt.to_string_lossy().to_string();
+
+    debug!("Destroying LUKS volume id={}", id);
+
+    // 1. umount. -l (lazy) handles the case where the container is
+    //    still holding a file open during teardown — the kernel
+    //    detaches the mount the moment the last reference drops.
+    if mnt.exists() {
+        let out = Command::new("umount").args(["-l", &mnt_str]).output().await;
+        match out {
+            Ok(o) if !o.status.success() => {
+                let stderr = String::from_utf8_lossy(&o.stderr);
+                if !stderr.contains("not mounted") {
+                    warn!("umount {} non-fatal error: {}", mnt_str, stderr.trim());
+                }
+            }
+            Err(e) => warn!("umount {} could not exec: {}", mnt_str, e),
+            _ => {}
+        }
+    }
+
+    // 2. luksClose. Idempotent: cryptsetup returns 0 on success and
+    //    a non-zero on "not active", which we tolerate.
+    let _ = run("cryptsetup", &["luksClose", &mapper_n]).await;
+
+    // 3. luksErase wipes ALL keyslots without needing the original
+    //    key (--batch-mode bypasses the "are you really sure" prompt).
+    //    After this, the LUKS header has no recoverable keyslot;
+    //    even if the operator extracted the file before step 4,
+    //    the AES-XTS payload is unreachable.
+    if img.exists() {
+        let out = Command::new("cryptsetup")
+            .args(["luksErase", "--batch-mode", &img_str])
+            .output()
+            .await;
+        if let Ok(o) = out {
+            if !o.status.success() {
+                warn!(
+                    "cryptsetup luksErase {} non-fatal: {}",
+                    img_str,
+                    String::from_utf8_lossy(&o.stderr).trim()
+                );
+            }
+        }
+    }
+
+    // 4. rm the sparse file. Best-effort; the disk space matters
+    //    more than the ciphertext (which is keyless after step 3).
+    if img.exists() {
+        if let Err(e) = tokio::fs::remove_file(&img).await {
+            warn!("remove {} non-fatal: {}", img.display(), e);
+        }
+    }
+
+    // 5. rmdir the mountpoint. Cosmetic.
+    if mnt.exists() {
+        let _ = tokio::fs::remove_dir(&mnt).await;
+    }
+
+    Ok(())
+}
+
+/// Spawn `prog` with `args` and feed `key` on stdin (for cryptsetup
+/// `--key-file=-`). The key bytes never appear on the command line
+/// (where `ps` would expose them) or in any log.
+async fn run_with_key_stdin(prog: &str, args: &[&str], key: &[u8; 32]) -> Result<()> {
+    let mut child = Command::new(prog)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("spawn {}", prog))?;
+    {
+        let stdin = child.stdin.as_mut().context("child stdin not piped")?;
+        stdin.write_all(key).await.context("write key to stdin")?;
+        stdin.shutdown().await.context("close key stdin")?;
+    }
+    let out = child
+        .wait_with_output()
+        .await
+        .with_context(|| format!("wait for {}", prog))?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "{} {:?} failed: {}",
+            prog,
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(())
+}
+
+/// Spawn `prog` with `args` (no stdin), best-effort silent. Returns
+/// the success bool so callers can log without short-circuiting on
+/// "not present" cleanups.
+async fn run(prog: &str, args: &[&str]) -> bool {
+    Command::new(prog)
+        .args(args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paths_are_id_scoped_and_under_volume_root() {
+        let img = image_path(42);
+        let mnt = mount_path(42);
+        let dev = mapper_device(42);
+        assert!(
+            img.starts_with(VOLUME_ROOT),
+            "image not under VOLUME_ROOT: {}",
+            img.display()
+        );
+        assert!(
+            mnt.starts_with(VOLUME_ROOT),
+            "mount not under VOLUME_ROOT: {}",
+            mnt.display()
+        );
+        assert_eq!(img.file_name().unwrap(), "42.luks");
+        assert_eq!(mnt.file_name().unwrap(), "42");
+        assert_eq!(dev, PathBuf::from("/dev/mapper/paygress-42-luks"));
+    }
+
+    #[test]
+    fn mapper_name_is_distinct_per_id() {
+        assert_ne!(mapper_name(1), mapper_name(2));
+        assert_eq!(mapper_name(7), "paygress-7-luks");
+    }
+
+    #[test]
+    fn paths_for_different_ids_do_not_collide() {
+        assert_ne!(image_path(1), image_path(2));
+        assert_ne!(mount_path(1), mount_path(2));
+    }
+}

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1069,6 +1069,49 @@ async fn handle_spawn_request(
         .as_ref()
         .and_then(|t| t.data_path.map(|p| p.to_string()));
 
+    // Volume encryption (Phase 2): decode the consumer-supplied key
+    // from the spawn request. Silently None for stateless workloads
+    // (data_path is None) since there's nothing to encrypt — saves
+    // surfacing a confusing "key supplied but ignored" warning to a
+    // consumer who set --encrypt-volume on a stateless template.
+    let volume_encryption_key = match (&data_path, request.volume_encryption.as_ref()) {
+        (Some(_), Some(ve)) => match ve.decoded_key() {
+            Ok(key) => {
+                info!(
+                    "Spawn request includes volume_encryption (algorithm={}, version={}); will create LUKS-encrypted data volume",
+                    ve.algorithm, ve.version
+                );
+                Some(key)
+            }
+            Err(e) => {
+                error!(
+                    "Rejecting spawn: malformed volume_encryption.key_b64: {}",
+                    e
+                );
+                let err_payload = ErrorResponseContent {
+                    error_type: "invalid_volume_encryption".to_string(),
+                    message: format!("volume_encryption rejected: {}", e),
+                    details: None,
+                };
+                let _ = nostr
+                    .send_error_response_private_message(
+                        requester_pubkey,
+                        err_payload,
+                        message_type,
+                    )
+                    .await;
+                return Ok(());
+            }
+        },
+        (None, Some(_)) => {
+            warn!(
+                "Spawn request set volume_encryption but template has no data_path; encryption is a no-op for stateless workloads"
+            );
+            None
+        }
+        _ => None,
+    };
+
     // 7. Create Container
     let container_config = ContainerConfig {
         id,
@@ -1084,6 +1127,7 @@ async fn handle_spawn_request(
         template_env,
         extra_runtime_args,
         data_path,
+        volume_encryption_key,
     };
 
     // ---- Standby branch ----

--- a/tests/templates_spawn.rs
+++ b/tests/templates_spawn.rs
@@ -139,6 +139,7 @@ fn container_config_carries_template_data() {
             .map(|s| s.to_string())
             .collect(),
         data_path: def.data_path.map(|p| p.to_string()),
+        volume_encryption_key: None,
     };
     assert_eq!(cfg.template_ports.len(), 1);
     assert_eq!(cfg.template_ports[0].container_port, 7777);


### PR DESCRIPTION
## Replay of #47 — same content, retargeted to main

PR #47 was merged via the GitHub UI but its base was the (now-orphan) `feat/volume-encryption-wire` branch instead of `main`, so its diff never landed on main. This PR is the same commit replayed on top of current main.

The original PR description applies verbatim — see [#47](https://github.com/DhananjayPurohit/Paygress/pull/47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)