### PR TITLE
feat(privacy): default-on volume encryption for stateful templates [replay of #48]

### DIFF
--- a/src/cli/commands/deploy.rs
+++ b/src/cli/commands/deploy.rs
@@ -282,11 +282,15 @@ pub async fn execute(args: DeployArgs, verbose: bool) -> Result<()> {
         // provider in the set.
         primary_npub: None,
         workload_id: None,
-        // Per-template encryption defaults land with Phase 2; for now
-        // deploy does not flip --encrypt-volume on its own. Consumers
-        // who want encryption use `paygress-cli spawn --encrypt-volume`
-        // directly.
+        // `spawn::execute` honors the template's encrypt-by-default
+        // policy via `template_default_encrypts_volume(template_slug)`,
+        // so leaving both flags `false` here means stateful templates
+        // (data_path: Some(_)) get LUKS encryption automatically. To
+        // override at the deploy CLI, expose `--encrypt-volume` /
+        // `--no-encrypt-volume` flags here in a follow-up; today the
+        // overrides live on `paygress-cli spawn`.
         encrypt_volume: false,
+        no_encrypt_volume: false,
     };
     spawn::execute(spawn_args, verbose).await
 }

--- a/src/cli/commands/spawn.rs
+++ b/src/cli/commands/spawn.rs
@@ -113,20 +113,32 @@ pub struct SpawnArgs {
     #[arg(long)]
     pub workload_id: Option<String>,
 
-    /// Encrypt the workload's persistent data volume with a key
-    /// derived from your nsec + workload-id. Defends against
+    /// Force-encrypt the workload's persistent data volume with a
+    /// key derived from your nsec + workload-id. Defends against
     /// post-eviction disk forensics, lazy host backups, co-tenant
     /// attacks on shared storage, and cold-disk seizure. Does NOT
     /// defend against a live host kernel reading process memory or
-    /// extracting the LUKS key from the keyring — that requires
-    /// a confidential VM (`isolation-level=attested-research-tier`).
+    /// extracting the LUKS key from the keyring — that requires a
+    /// confidential VM (`isolation-level=attested-research-tier`).
     ///
-    /// When set, `--workload-id` becomes effectively required (the
-    /// CLI generates a UUID if you don't supply one and prints it
-    /// so you can re-supply it on respawn / top-up to recover the
-    /// same key).
-    #[arg(long)]
+    /// You usually do not need this flag: encryption defaults ON
+    /// for any template that holds persistent state (`data_path:
+    /// Some(_)`). Use `--no-encrypt-volume` to opt out.
+    ///
+    /// When encryption is on (by flag or by default), the CLI
+    /// derives the key deterministically from your nsec +
+    /// workload-id; if `--workload-id` is not supplied, a UUIDv4
+    /// is generated and printed so you can re-supply it on respawn
+    /// / top-up to recover the same key.
+    #[arg(long, conflicts_with = "no_encrypt_volume")]
     pub encrypt_volume: bool,
+
+    /// Opt out of the per-template default for encrypted volumes.
+    /// Use when you've consciously decided the workload's data
+    /// doesn't warrant the LUKS overhead, or when debugging an
+    /// encryption-related provider issue.
+    #[arg(long, conflicts_with = "encrypt_volume")]
+    pub no_encrypt_volume: bool,
 }
 
 /// Translate the `--replication` + `--standby` CLI flags into the
@@ -431,12 +443,34 @@ async fn execute_nostr_spawn(
 
     // Volume encryption: derive a 32-byte key from (nsec, workload_id)
     // and ship it inside the encrypted spawn DM. The provider creates
-    // a LUKS-encrypted volume keyed by these bytes (Phase 2 of the
-    // confidentiality plan; today the provider parses but doesn't
-    // yet act). If the consumer didn't supply --workload-id, mint a
-    // UUIDv4 so the key is reproducible on respawn.
+    // a LUKS-encrypted volume keyed by these bytes.
+    //
+    // Three-way truth table for whether to encrypt:
+    //   --no-encrypt-volume        → false (explicit opt-out)
+    //   --encrypt-volume           → true  (explicit force-on)
+    //   neither + known template   → template_default_encrypts_volume
+    //   neither + unknown template → false (consumer didn't ask)
+    //
+    // The "by default" case reaches in via the template_slug; if the
+    // consumer supplied a slug the CLI knows, we honor that template's
+    // policy. Custom-image spawns (no slug) keep the historical
+    // "off-by-default" behavior so we don't surprise existing scripts.
+    let template_default_encrypt = args
+        .template_slug
+        .as_deref()
+        .and_then(paygress::templates::TemplateName::from_slug)
+        .map(paygress::templates::template_default_encrypts_volume)
+        .unwrap_or(false);
+    let should_encrypt = if args.no_encrypt_volume {
+        false
+    } else if args.encrypt_volume {
+        true
+    } else {
+        template_default_encrypt
+    };
+
     let mut effective_workload_id = args.workload_id.clone();
-    let volume_encryption = if args.encrypt_volume {
+    let volume_encryption = if should_encrypt {
         if effective_workload_id.is_none() {
             let id = uuid::Uuid::new_v4().to_string();
             println!(
@@ -449,6 +483,12 @@ async fn execute_nostr_spawn(
         let workload_id = effective_workload_id.as_ref().unwrap();
         let nsec_bytes = nsec_to_bytes(&nostr_key)?;
         let key = paygress::volume_encryption::derive_volume_key(&nsec_bytes, workload_id);
+        if !args.encrypt_volume && template_default_encrypt {
+            println!(
+                "  {} (template default; pass --no-encrypt-volume to skip)",
+                "Encrypting persistent data volume".green()
+            );
+        }
         Some(paygress::nostr::VolumeEncryption::v1(key))
     } else {
         None

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -177,6 +177,30 @@ impl TemplateDefinition {
     }
 }
 
+/// Default policy for `--encrypt-volume` on the spawn CLI: should
+/// the consumer's data volume be LUKS-encrypted at rest *unless
+/// they explicitly pass `--no-encrypt-volume`*?
+///
+/// Rule: yes for every template that holds persistent state
+/// (`data_path: Some(_)`). Stateless templates have nothing to
+/// encrypt and the default is a no-op for them.
+///
+/// Why this rule and not "Checkpointed only": every persistent-state
+/// template leaks the *same* class of data to a curious operator —
+/// strfry's LMDB has relay subscribers' message graph, ollama's
+/// model dir carries any RAG context, openclaw's config dir holds
+/// chat-app credentials, bitcoind's chaindata carries the wallet
+/// pubkeys. The replication mode is a recovery-model knob, not a
+/// confidentiality knob; encryption is justified in all of them.
+/// Modest LUKS overhead beats a confused consumer-vs-template-
+/// author trust split.
+///
+/// Pure function over the template name — testable without
+/// touching the filesystem or the network.
+pub fn template_default_encrypts_volume(name: TemplateName) -> bool {
+    TemplateDefinition::lookup(name).data_path.is_some()
+}
+
 fn nostr_relay() -> TemplateDefinition {
     let mut env = HashMap::new();
     env.insert("STRFRY_DB_PATH", "/app/strfry-db");
@@ -484,5 +508,52 @@ fn openclaw() -> TemplateDefinition {
         min_cpu_millicores: 1000,
         min_memory_mb: 2048,
         min_storage_gb: 5,
+    }
+}
+
+#[cfg(test)]
+mod default_policy_tests {
+    use super::*;
+
+    #[test]
+    fn templates_with_persistent_state_default_to_encrypted() {
+        // Anything with a `data_path` should get encrypted by default.
+        // Stateful templates today: nostr-relay, inference-endpoint,
+        // bitcoin-node, agent-sandbox, openclaw.
+        for name in TemplateName::all() {
+            let def = TemplateDefinition::lookup(name);
+            let expected = def.data_path.is_some();
+            assert_eq!(
+                template_default_encrypts_volume(name),
+                expected,
+                "template {:?} default-encrypt mismatch (data_path={:?})",
+                name,
+                def.data_path,
+            );
+        }
+    }
+
+    #[test]
+    fn nostr_relay_encrypts_by_default() {
+        // strfry's LMDB carries subscribers' message graph; encrypting
+        // it at rest is justified even though replication is
+        // warm-standby (recovery mode is orthogonal to confidentiality).
+        assert!(template_default_encrypts_volume(TemplateName::NostrRelay));
+    }
+
+    #[test]
+    fn headless_browser_does_not_encrypt_by_default() {
+        // Stateless template — nothing to encrypt. The default is a
+        // no-op for it.
+        assert!(!template_default_encrypts_volume(
+            TemplateName::HeadlessBrowser
+        ));
+    }
+
+    #[test]
+    fn openclaw_encrypts_by_default() {
+        // OpenClaw's /data/.openclaw holds chat-app OAuth tokens —
+        // arguably the load-bearing reason this default exists.
+        assert!(template_default_encrypts_volume(TemplateName::OpenClaw));
     }
 }


### PR DESCRIPTION
Replay of #48 onto main (the original was merged into the stacked branch instead of main; same diff). Includes a new test asserting OpenClaw also defaults to encrypted, since the openclaw template landed via #45 between the original PR and this replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)