### PR TITLE
fix(failover): use dedicated promotion-announcement event for split-brain dedup

### DIFF
--- a/src/nostr.rs
+++ b/src/nostr.rs
@@ -41,6 +41,17 @@ pub const KIND_PROVIDER_HEARTBEAT_EPHEMERAL: u16 = 20384;
 /// and each standby is added as a `#p` tag for filterable subscriptions.
 pub const KIND_LEASE_REVOCATION: u16 = 38385;
 
+/// Published by a standby provider IMMEDIATELY after it finishes
+/// promoting a workload to local primary. Other standbys for the
+/// same workload check for one of these events before claiming
+/// their own slot, so only the lowest-indexed standby that wins
+/// the promotion race actually spawns a container — the rest see
+/// the announcement and drop their slot. NIP-33 addressable: the
+/// `d` tag is `paygress:promoted:v1:<workload_id>`, so subsequent
+/// announcements for the same workload (e.g. a re-failover) replace
+/// the previous one rather than accumulating.
+pub const KIND_STANDBY_PROMOTION_ANNOUNCEMENT: u16 = 38386;
+
 /// Schema version for offer + heartbeat payloads. Old payloads
 /// without this field deserialize to `1` via `#[serde(default)]`.
 pub const SCHEMA_VERSION: u8 = 1;
@@ -1099,6 +1110,29 @@ pub struct LeaseRevocationContent {
     pub version: u8,
 }
 
+/// Published by a standby provider IMMEDIATELY after it finishes
+/// promoting a workload to local primary. Distinguishable from a
+/// regular periodic heartbeat because the heartbeat says "this
+/// provider is online" whereas this event says "this provider has
+/// just claimed this workload's primary role". Higher-indexed
+/// peers query for these events at promotion-time and drop their
+/// slot if they see one from a peer for the same workload_id.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StandbyPromotionAnnouncementContent {
+    /// Consumer-assigned workload identifier (the same UUID-shaped
+    /// string used by `LeaseRevocationContent.workload_id` and the
+    /// spawn request's `workload_id`).
+    pub workload_id: String,
+    /// The npub of the standby provider that has just promoted to
+    /// primary. Peers compare this against their own npub to
+    /// confirm the claim is from a peer (not themselves).
+    pub new_primary_npub: String,
+    /// Unix-second timestamp at which the promotion completed.
+    pub promoted_at: u64,
+    #[serde(default = "default_schema_version")]
+    pub version: u8,
+}
+
 /// Provider info as seen by discovery clients
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderInfo {
@@ -1297,6 +1331,99 @@ impl NostrRelaySubscriber {
                 Err(e.into())
             }
         }
+    }
+
+    /// Publish a `StandbyPromotionAnnouncement` for a freshly-
+    /// promoted workload. NIP-33 addressable: `d` tag is
+    /// `paygress:promoted:v1:<workload_id>` so a re-failover for
+    /// the same workload replaces the prior announcement.
+    pub async fn publish_standby_promotion_announcement(
+        &self,
+        announcement: StandbyPromotionAnnouncementContent,
+    ) -> Result<String> {
+        let content = serde_json::to_string(&announcement)?;
+        let d_tag = format!(
+            "paygress:promoted:v{}:{}",
+            announcement.version, announcement.workload_id
+        );
+        let v_tag = announcement.version.to_string();
+        let tags = vec![
+            Tag::hashtag("paygress"),
+            Tag::hashtag("paygress-promoted"),
+            Tag::parse(["d", d_tag.as_str()])?,
+            Tag::parse(["v", v_tag.as_str()])?,
+            Tag::parse(["workload", announcement.workload_id.as_str()])?,
+        ];
+
+        let event = EventBuilder::new(Kind::Custom(KIND_STANDBY_PROMOTION_ANNOUNCEMENT), content)
+            .tags(tags)
+            .sign_with_keys(&self.keys)?;
+        let event_id = event.id.to_hex();
+
+        match self.client.send_event(&event).await {
+            Ok(out) => {
+                info!(
+                    "📢 Standby promotion announcement published for workload {}: {} accepted by {} relay(s)",
+                    announcement.workload_id,
+                    event_id,
+                    out.success.len()
+                );
+                Ok(event_id)
+            }
+            Err(e) => {
+                error!("Failed to publish standby promotion announcement: {}", e);
+                Err(e.into())
+            }
+        }
+    }
+
+    /// Query for any `StandbyPromotionAnnouncement` for `workload_id`
+    /// authored by one of `peer_npubs`. Returns the first matching
+    /// event's content (or None). The watchdog/promotion path uses
+    /// this BEFORE spawning a container to detect that a peer has
+    /// already promoted; if any event is found, the local standby
+    /// drops its slot rather than producing a duplicate primary.
+    pub async fn query_standby_promotion_announcements(
+        &self,
+        workload_id: &str,
+        peer_npubs: &[String],
+    ) -> Result<Option<StandbyPromotionAnnouncementContent>> {
+        if peer_npubs.is_empty() {
+            return Ok(None);
+        }
+        let mut authors = Vec::new();
+        for npub in peer_npubs {
+            if let Ok(pk) = nostr_sdk::PublicKey::parse(npub) {
+                authors.push(pk);
+            }
+        }
+        if authors.is_empty() {
+            return Ok(None);
+        }
+
+        let filter = Filter::new()
+            .kind(Kind::Custom(KIND_STANDBY_PROMOTION_ANNOUNCEMENT))
+            .authors(authors)
+            .custom_tag(
+                nostr_sdk::SingleLetterTag::lowercase(nostr_sdk::Alphabet::D),
+                format!("paygress:promoted:v{}:{}", SCHEMA_VERSION, workload_id),
+            );
+
+        let events = self
+            .client
+            .fetch_events(filter, std::time::Duration::from_secs(5))
+            .await?;
+
+        for event in events.iter() {
+            if let Ok(content) =
+                serde_json::from_str::<StandbyPromotionAnnouncementContent>(&event.content)
+            {
+                if content.workload_id == workload_id {
+                    return Ok(Some(content));
+                }
+            }
+        }
+        Ok(None)
     }
 
     /// Query all provider offers from relays

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -26,8 +26,8 @@ use crate::nostr::{
     parse_private_message_content, warm_standby_role, AccessDetailsContent, CapacityInfo,
     EncryptedSpawnPodRequest, EncryptedTopUpPodRequest, ErrorResponseContent, HeartbeatContent,
     LeaseRevocationContent, NostrRelaySubscriber, PodSpec, PrivateRequest, ProviderOfferContent,
-    RelayConfig, StatusRequestContent, StatusResponseContent, TopUpResponseContent,
-    WarmStandbyRole,
+    RelayConfig, StandbyPromotionAnnouncementContent, StatusRequestContent, StatusResponseContent,
+    TopUpResponseContent, WarmStandbyRole,
 };
 use crate::proxmox::{ProxmoxBackend, ProxmoxClient};
 use crate::templates::{TemplateDefinition, TemplateName};
@@ -2024,25 +2024,16 @@ fn compute_warm_standby_role(
     }
 }
 
-/// How fresh a peer-standby heartbeat must be (in seconds, relative
-/// to the moment we evaluate it) to count as evidence that a peer
-/// has already promoted to primary. Heartbeat cadence is 60s; we
-/// give two cadences of grace so a momentarily-flaky relay
-/// subscription doesn't make a higher-indexed standby falsely
-/// proceed and split-brain.
-const PEER_PROMOTION_FRESH_SECS: u64 = 120;
-
 /// Spawn the standby promotion task. Runs on its own tokio task so
 /// the request handler returns immediately. Sleeps for the
 /// per-standby ordered backoff, then:
-///   1. Pre-emption check — query heartbeats from peer standbys.
-///      If any has a fresh heartbeat (within the last
-///      PEER_PROMOTION_FRESH_SECS), assume that peer has already
-///      promoted; drop the slot and return without spawning.
+///   1. Pre-emption check — query for any
+///      `StandbyPromotionAnnouncement` event for this workload_id
+///      authored by a peer standby. If one exists, drop the slot
+///      without spawning (a peer beat us to it).
 ///   2. Spawn the container locally.
-///   3. Publish a heartbeat immediately so higher-indexed peers
-///      see fresh evidence on their next pre-emption check and
-///      back off without spawning a duplicate primary.
+///   3. Publish a `StandbyPromotionAnnouncement` so higher-indexed
+///      peers' pre-emption check finds it and they back off.
 fn schedule_standby_promotion(
     backend: Arc<dyn ComputeBackend>,
     workloads: Arc<Mutex<HashMap<u32, WorkloadInfo>>>,
@@ -2084,40 +2075,34 @@ fn schedule_standby_promotion(
             }
         };
 
-        // Pre-emption check: has a peer standby already promoted?
-        // Query heartbeats from each peer's npub; if any is fresh
-        // (published within the last PEER_PROMOTION_FRESH_SECS),
-        // that peer is now primary and we should NOT promote.
-        // Without this check N standbys all promote at silence-
-        // detection + index*backoff, producing N concurrent
-        // primaries running the same workload (split-brain).
+        // Pre-emption check: has a peer standby already promoted
+        // for this exact workload_id? Query the dedicated
+        // `StandbyPromotionAnnouncement` event kind (38386), which
+        // is published exactly once per promotion. Heartbeats can't
+        // serve this role: every standby provider runs a periodic
+        // heartbeat loop regardless of promotion state, so a fresh
+        // heartbeat from a peer means "peer is online", NOT "peer
+        // promoted". The announcement event is unambiguous.
         if !slot.peer_standby_npubs.is_empty() {
             match nostr
-                .get_latest_heartbeats_multi(slot.peer_standby_npubs.clone())
+                .query_standby_promotion_announcements(&slot.workload_id, &slot.peer_standby_npubs)
                 .await
             {
-                Ok(peer_heartbeats) => {
-                    let now = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_secs())
-                        .unwrap_or(0);
-                    if let Some((peer_npub, hb)) = peer_heartbeats.iter().find(|(_, hb)| {
-                        now.saturating_sub(hb.timestamp) <= PEER_PROMOTION_FRESH_SECS
-                    }) {
-                        info!(
-                            "Peer standby {} already promoted (fresh heartbeat at {}s ago, threshold {}s); \
-                             dropping slot for workload {} without spawning",
-                            peer_npub,
-                            now.saturating_sub(hb.timestamp),
-                            PEER_PROMOTION_FRESH_SECS,
-                            slot.workload_id
-                        );
-                        return;
-                    }
+                Ok(Some(announcement)) => {
+                    info!(
+                        "Peer standby {} already promoted workload {} at {}; dropping slot without spawning",
+                        announcement.new_primary_npub,
+                        announcement.workload_id,
+                        announcement.promoted_at
+                    );
+                    return;
+                }
+                Ok(None) => {
+                    // No peer has announced — proceed with promotion.
                 }
                 Err(e) => {
                     warn!(
-                        "Failed to query peer standby heartbeats for workload {}: {}; proceeding with promotion (best-effort)",
+                        "Failed to query peer promotion announcements for workload {}: {}; proceeding with promotion (best-effort)",
                         slot.workload_id, e
                     );
                 }
@@ -2189,27 +2174,28 @@ fn schedule_standby_promotion(
             "Standby promotion complete: workload {} now running locally (vmid {})",
             slot.workload_id, slot.container_config.id
         );
+        let _ = active_workloads_count; // currently unused now that we publish announcement instead of heartbeat
 
-        // Publish a heartbeat IMMEDIATELY so higher-indexed peer
-        // standbys see fresh evidence of an already-promoted peer
-        // on their next pre-emption check. Without this the
-        // periodic heartbeat loop runs every 60s and a peer's
-        // backoff might expire before the first heartbeat lands,
-        // producing a duplicate primary.
-        let immediate_heartbeat = HeartbeatContent {
-            provider_npub: nostr.get_service_public_key(),
-            timestamp: now,
-            active_workloads: active_workloads_count,
-            available_capacity: CapacityInfo {
-                cpu_available: 0,
-                memory_mb_available: 0,
-                storage_gb_available: 0,
-            },
+        // Publish a `StandbyPromotionAnnouncement` IMMEDIATELY so
+        // higher-indexed peer standbys see it on their next
+        // pre-emption check (which fires after their per-index
+        // backoff). Without this announcement, peers would either
+        // produce a duplicate primary (no signal) or both drop
+        // their slots (heartbeat-based dedup, since every peer
+        // emits its own periodic heartbeat regardless of
+        // promotion state).
+        let announcement = StandbyPromotionAnnouncementContent {
+            workload_id: slot.workload_id.clone(),
+            new_primary_npub: nostr.get_service_public_key(),
+            promoted_at: now,
             version: crate::nostr::SCHEMA_VERSION,
         };
-        if let Err(e) = nostr.publish_heartbeat(immediate_heartbeat).await {
+        if let Err(e) = nostr
+            .publish_standby_promotion_announcement(announcement)
+            .await
+        {
             warn!(
-                "Post-promotion heartbeat publish failed for workload {}: {}; periodic loop will catch up on next tick",
+                "Post-promotion announcement publish failed for workload {}: {}; peer standbys will not back off and may produce a duplicate primary",
                 slot.workload_id, e
             );
         }


### PR DESCRIPTION
## Summary

- PR #59's heartbeat-based dedup was wrong: every standby provider runs a periodic heartbeat loop regardless of promotion state, so peers seeing each other's heartbeats can't tell "peer is online" from "peer promoted." On the VPS reproducer this caused BOTH standbys to drop their slots, leaving the workload with no primary.
- Add a dedicated event kind \`38386 = KIND_STANDBY_PROMOTION_ANNOUNCEMENT\` published exactly once per promotion. Addressable so re-failovers replace prior announcements.
- Promotion path: after backoff, query for any 38386 event for this workload_id authored by a peer; if found → drop slot. Otherwise spawn + publish 38386.
- Removes \`get_latest_heartbeats_multi\` pre-emption call and the immediate-heartbeat-on-promote from #59.

## VPS reproducer (test #66)

Before this PR: standby 1 promoted at 17:48:10 vmid 2001, BOTH then dropped because each saw the other's regular heartbeat. Workload had no primary.

With this PR (expected):
- Standby 1 wakes at backoff=0s, queries 38386 → none → spawns + publishes 38386
- Standby 2 wakes at backoff=30s, queries 38386 → finds standby 1's announcement → drops slot

## Test plan

- [x] \`cargo test --release --all-features\`: 229 tests, 0 failures
- [ ] VPS: re-run failover; expect exactly one promoted vmid

🤖 Generated with [Claude Code](https://claude.com/claude-code)