### PR TITLE
chore: clean up unused imports and dead status_info branch

### DIFF
--- a/src/cli/commands/provider.rs
+++ b/src/cli/commands/provider.rs
@@ -229,7 +229,7 @@ pub async fn execute(args: ProviderArgs, verbose: bool) -> Result<()> {
     }
 }
 
-async fn execute_setup(args: SetupArgs, verbose: bool) -> Result<()> {
+async fn execute_setup(args: SetupArgs, _verbose: bool) -> Result<()> {
     println!("{}", "🔧 Paygress Provider Setup".blue().bold());
     println!("{}", "━".repeat(50).blue());
     println!();
@@ -659,7 +659,7 @@ async fn execute_setup_multi(args: SetupMultiArgs, _verbose: bool) -> Result<()>
     Ok(())
 }
 
-async fn execute_start(args: StartArgs, verbose: bool) -> Result<()> {
+async fn execute_start(args: StartArgs, _verbose: bool) -> Result<()> {
     println!("{}", "🚀 Starting Paygress Provider".blue().bold());
     println!();
 

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -3,13 +3,10 @@
 // Used by end users to discover available providers on Nostr
 // and interact with them for spawning workloads.
 
-use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
-use tracing::{info, warn};
+use anyhow::Result;
+use tracing::info;
 
-use crate::nostr::{
-    NostrRelaySubscriber, PodSpec, ProviderFilter, ProviderInfo, ProviderOfferContent, RelayConfig,
-};
+use crate::nostr::{NostrRelaySubscriber, ProviderFilter, ProviderInfo, RelayConfig};
 
 /// Discovery client for finding providers
 pub struct DiscoveryClient {
@@ -404,6 +401,7 @@ fn truncate_str(s: &str, max_len: usize) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::nostr::PodSpec;
 
     #[test]
     fn test_format_provider_table() {

--- a/src/lxd.rs
+++ b/src/lxd.rs
@@ -7,7 +7,7 @@ use crate::compute::{ComputeBackend, ContainerConfig, NodeStatus};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use std::process::Command;
-use tracing::{info, warn};
+use tracing::info;
 
 pub struct LxdBackend {
     storage_pool: String,

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -629,7 +629,6 @@ impl ProviderService {
                         }
                         PrivateRequest::Status(status_req) => {
                             if let Err(e) = handle_status_request(
-                                backend.as_ref(),
                                 &config,
                                 &nostr,
                                 &workloads,
@@ -1875,7 +1874,6 @@ fn redeem_error_to_response(err: &RedeemError) -> (&'static str, String) {
 
 /// Handle a status request
 async fn handle_status_request(
-    backend: &dyn ComputeBackend,
     config: &ProviderConfig,
     nostr: &NostrRelaySubscriber,
     workloads: &Arc<Mutex<HashMap<u32, WorkloadInfo>>>,
@@ -1918,19 +1916,7 @@ async fn handle_status_request(
         }
     };
 
-    // 2. Check backend status
-    let status_info = match backend.get_node_status().await {
-        Ok(s) => s,
-        Err(_) => crate::compute::NodeStatus {
-            cpu_usage: 0.0,
-            memory_used: 0,
-            memory_total: 0,
-            disk_used: 0,
-            disk_total: 0,
-        },
-    };
-
-    // 3. Prepare response
+    // 2. Prepare response
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)?
         .as_secs();

--- a/src/proxmox.rs
+++ b/src/proxmox.rs
@@ -5,7 +5,7 @@
 use anyhow::{Context, Result};
 use reqwest::{header, Client};
 use serde::{Deserialize, Serialize};
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 /// Proxmox API client for container and VM management
 pub struct ProxmoxClient {


### PR DESCRIPTION
## Summary

- Drop unused imports in \`src/discovery.rs\`, \`src/lxd.rs\`, \`src/proxmox.rs\`. Move \`PodSpec\` into the discovery test module since it's only referenced there.
- Drop a dead \`status_info\` block in \`handle_status_request\` — the value was bound and never read. Drop the now-unused \`backend\` parameter and update the lone caller.
- Underscore-prefix the unused \`verbose\` parameter in \`execute_setup\` / \`execute_start\` (kept in the API signature for parity with other action handlers).

Lib warnings 11 → 4, bin warnings 6 → 4. Remaining warnings are intentional dead-code-as-API or future-use scaffolding.

## Test plan

- [x] \`cargo test --release --all-features\`: 233 passing, 0 failures (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)