### PR TITLE
fix(provider): default whitelisted mint to testnut so fresh providers are usable

### DIFF
--- a/src/cashu.rs
+++ b/src/cashu.rs
@@ -242,11 +242,11 @@ pub fn derive_seed_from_nostr_key(nostr_private_key: &str) -> [u8; 64] {
 /// remainder so the totals reconcile exactly.
 ///
 /// Caveats:
-///   - This is `cdk::wallet` 0.9. Modern mints with v2 (66-char)
-///     keyset IDs (e.g. mint.minibits.cash) may fail at receive due
-///     to the same parsing issue we hit on the redeemer side. Tested
-///     today against `testnut.cashu.space`. cdk 0.14 upgrade is
-///     tracked separately.
+///   - Exercised end-to-end against `testnut.cashu.space` only.
+///     The bundled cdk 0.14 wallet supports v2 (66-char) keyset
+///     IDs in code, so mainnet mints (e.g. `mint.minibits.cash`)
+///     are expected to work for receive+split, but that path has
+///     not been verified against a live mainnet mint yet.
 ///   - The wallet's localstore at `db_path` is left in place after
 ///     the split; callers wanting truly ephemeral semantics should
 ///     remove it. The batch coordinator does.

--- a/src/cli/commands/batch.rs
+++ b/src/cli/commands/batch.rs
@@ -53,10 +53,11 @@ pub struct BatchArgs {
     /// token in, and emits N tokens of approximately equal face
     /// value before fanning out spawns.
     ///
-    /// Caveat: uses `cdk` 0.9, which is known to fail at receive
-    /// against modern mints with v2 (66-char) keyset IDs (e.g.
-    /// mint.minibits.cash). Works today against testnut.cashu.space.
-    /// cdk 0.14 upgrade is tracked separately.
+    /// Caveat: exercised end-to-end against `testnut.cashu.space`
+    /// only. The bundled cdk 0.14 wallet supports v2 (66-char)
+    /// keyset IDs in code, so mainnet mints (e.g.
+    /// `mint.minibits.cash`) are expected to work, but that path
+    /// has not been verified against a live mainnet mint yet.
     #[arg(long)]
     pub split_token: Option<String>,
 

--- a/src/cli/commands/bootstrap.rs
+++ b/src/cli/commands/bootstrap.rs
@@ -44,8 +44,12 @@ pub struct BootstrapArgs {
     #[arg(long)]
     pub nostr_key: Option<String>,
 
-    /// Whitelisted Cashu mints (comma-separated)
-    #[arg(long, default_value = "https://mint.minibits.cash")]
+    /// Whitelisted Cashu mints (comma-separated). Defaults to the
+    /// `testnut.cashu.space` testnet mint — see
+    /// `cli::commands::provider::SetupArgs::mints` for the rationale
+    /// (mainnet receive flow unverified end-to-end against this cdk
+    /// version).
+    #[arg(long, default_value = "https://testnut.cashu.space")]
     pub mints: String,
 
     /// Skip Proxmox installation (assumes already installed)

--- a/src/cli/commands/provider.rs
+++ b/src/cli/commands/provider.rs
@@ -108,8 +108,17 @@ pub struct SetupArgs {
     #[arg(long)]
     pub public_ip: Option<String>,
 
-    /// Whitelisted Cashu mints (comma-separated)
-    #[arg(long, default_value = "https://mint.minibits.cash")]
+    /// Whitelisted Cashu mints (comma-separated). Defaults to
+    /// `testnut.cashu.space` — the testnet mint paygress's
+    /// integration paths exercise (`tests/cashu_redemption.rs`,
+    /// `tests/cli_deploy.rs`). The bundled cdk 0.14 wallet supports
+    /// v2 keyset IDs in code, so mainnet mints (e.g.
+    /// `https://mint.minibits.cash/Bitcoin`) are expected to work
+    /// for receive+swap, but that flow has not been verified
+    /// end-to-end against a live mainnet mint yet. Operators who
+    /// have validated their own mainnet mint can override with
+    /// `--mints https://their.mint/path`.
+    #[arg(long, default_value = "https://testnut.cashu.space")]
     pub mints: String,
 }
 
@@ -160,8 +169,11 @@ pub struct SetupMultiArgs {
 
     /// Whitelisted Cashu mints (comma-separated). Same list applied
     /// to every provider (they're all on the same host so they have
-    /// the same network reachability).
-    #[arg(long, default_value = "http://localhost:3338")]
+    /// the same network reachability). Defaults to `testnut.cashu.space`
+    /// — see the single-provider `SetupArgs::mints` comment for why
+    /// the default is testnet rather than mainnet. Operators with a
+    /// local nutshell mint can pass `--mints http://localhost:3338`.
+    #[arg(long, default_value = "https://testnut.cashu.space")]
     pub mints: String,
 
     /// Public IP address (auto-detected if not provided). Same value
@@ -1108,7 +1120,7 @@ mod setup_multi_tests {
             count,
             backend: paygress::provider::BackendType::Docker,
             name: "test".to_string(),
-            mints: "http://localhost:3338".to_string(),
+            mints: "https://testnut.cashu.space".to_string(),
             public_ip: Some("203.0.113.1".to_string()),
             no_systemd: true,
         }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -146,7 +146,7 @@ impl Default for ProviderConfig {
                 memory_mb: 1024,
                 rate_msats_per_sec: 50,
             }],
-            whitelisted_mints: vec!["https://mint.minibits.cash".to_string()],
+            whitelisted_mints: vec!["https://testnut.cashu.space".to_string()],
             heartbeat_interval_secs: 60,
             minimum_duration_seconds: 60,
             tunnel_enabled: false,


### PR DESCRIPTION
## Summary

Fresh providers came up advertising a mint nobody could pay against:

- `provider setup-multi` defaulted `--mints` to `http://localhost:3338` — a phantom local mint. Every provider scaffolded from a multi-host runbook was dead on arrival.
- `provider setup`, `bootstrap`, and `ProviderConfig::default()` defaulted to `https://mint.minibits.cash` — a bare host that returns 404. The real Cashu endpoint is at `/Bitcoin`. Same dead-on-arrival outcome, just less obvious.

Flip all four default sites to `https://testnut.cashu.space`. That's the testnet mint paygress's own integration paths exercise (`tests/cashu_redemption.rs:35`, `tests/cli_deploy.rs:86`), and the only mint with verified end-to-end coverage against the bundled cdk wallet today. Operators who've validated their own mainnet mint against this cdk version can override with `--mints`.

## Why testnet, not mainnet

The library blocker that previously gated mainnet (cdk parsing of v2 / 66-char keyset IDs) is lifted on paper — `Cargo.lock` shows `cdk 0.14.3` + `cashu 0.14.3`, and `cashu-0.14.3/src/nuts/nut02.rs` has explicit v2 support (`KeySetVersion::Version01`, `v2_from_data`, the dedicated `"Short keyset id does not match any of the provided IDv2s"` error path).

What's still missing is empirical confirmation: no test or operator runbook has yet exercised `Wallet::receive` against a live v2-keyset mainnet mint with this cdk version. Defaulting to a mint we *think* works but haven't proven is worse than defaulting to one we know works — both fail in production, but only the second one fails loudly during the standard test flow.

Once a mainnet mint is validated end-to-end (proposed as a follow-up: an `#[ignore]`'d integration test in `tests/cashu_redemption.rs` taking a real token via env vars), the defaults can be flipped to a mainnet pick.

## Files changed

- `src/cli/commands/provider.rs` — `SetupArgs::mints` and `SetupMultiArgs::mints` defaults; test fixture in `setup_multi_tests`
- `src/cli/commands/bootstrap.rs` — `BootstrapArgs::mints` default
- `src/provider.rs` — `ProviderConfig::default()` `whitelisted_mints`
- `src/cashu.rs`, `src/cli/commands/batch.rs` — drop stale `cdk 0.9 can't parse v2 keysets` comments that predated the cdk 0.14 bump

## Test plan

- [x] `cargo build --all-features` clean (warnings unchanged)
- [x] `cargo test --all-features setup_multi` — all 4 setup-multi tests pass
- [ ] On a clean host, `paygress-cli provider setup-multi` (no `--mints` override) produces three configs whose `whitelisted_mints` contain `https://testnut.cashu.space`, and `paygress-cli list info <npub>` shows it after start
- [ ] A spawn against a fresh provider using a testnut token succeeds end-to-end

## Out of scope / follow-ups

- Live end-to-end mainnet mint verification (the gate to promoting mainnet to default).
- Overwrite protection on `setup-multi` / `bootstrap` — re-running them today silently clobbers existing configs and (for `setup-multi`) rotates the nsec, losing provider identity. Worth a `--force` gate and per-instance `--nostr-key` handling, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)