### PR TITLE
fix: unbreak main, stop leaking expired containers, harden CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ on:
 permissions:
   contents: read
 
+# Superseded pushes cancel: every spawn costs a lease, and an
+# abandoned run's box stays rented until expiry.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -68,6 +74,8 @@ jobs:
             --amount "${{ vars.PAYGRESS_CI_SATS }}")
           echo "::add-mask::$TOKEN"
           echo "TOKEN=$TOKEN" >> "$GITHUB_ENV"
+      # Secrets go through env, not argv: Actions writes the step's
+      # command line to a script on disk and into the process table.
       # PAYGRESS_CI_IMAGE names a prebaked image on the provider
       # (runner + rust toolchain preinstalled — cuts ~3 min of
       # provisioning). Unset, it falls back to a stock image that the
@@ -75,6 +83,8 @@ jobs:
       # itself off when its one job ends, releasing the lease's
       # compute early.
       - name: Rent runner
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_RUNNER_PAT }}
         run: |
           ./target/debug/paygress-cli ci runner \
             --repo "${{ github.repository }}" \
@@ -83,8 +93,7 @@ jobs:
             --token "$TOKEN" \
             --image "${{ vars.PAYGRESS_CI_IMAGE || 'ubuntu:24.04' }}" \
             --labels "self-hosted,paygress,run-${{ github.run_id }}-${{ matrix.target }}" \
-            --skip-docker \
-            --github-token "${{ secrets.CI_RUNNER_PAT }}"
+            --skip-docker
 
   test:
     name: Test
@@ -92,7 +101,11 @@ jobs:
     runs-on: [self-hosted, paygress, "run-${{ github.run_id }}-test"]
     timeout-minutes: 90
     steps:
+      # persist-credentials: false — the job token would otherwise sit
+      # in .git/config on rented compute for the job's duration.
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # No-ops on the prebaked image; installs from scratch on a
       # stock one. The workload runs as root: no sudo.
       - name: Install system dependencies
@@ -105,7 +118,13 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
               sh -s -- -y --profile minimal --default-toolchain stable
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      # save-if: false — restore-only. A cache written from rented
+      # compute is a persistence channel that outlives the "one job,
+      # then gone" runner: poisoned build scripts and proc-macros
+      # would be restored (and executed) by later jobs.
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: false
       - name: cargo test --all-features
         run: cargo test --all-features
 
@@ -120,6 +139,8 @@ jobs:
     # docs/solutions/patterns/critical-patterns.md for the staging.
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install system dependencies
         run: |
           command -v cc >/dev/null || \
@@ -133,6 +154,8 @@ jobs:
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           "$HOME/.cargo/bin/rustup" component add clippy 2>/dev/null || true
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: false
       - name: cargo clippy (advisory)
         run: cargo clippy --all-targets --all-features
 
@@ -180,3 +203,28 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
       - name: cargo clippy (advisory)
         run: cargo clippy --all-targets --all-features
+
+  # The single required check. Without it, a provider outage skips
+  # `test` — and a skipped required check reads as green, i.e. the
+  # tests silently never ran. Skipped counts as failure here; only
+  # the fork/non-fork pair that was supposed to run may be skipped.
+  ci-gate:
+    name: CI gate
+    if: always()
+    needs: [fmt, test, clippy, test-fork, clippy-fork]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require tests to have actually run
+        run: |
+          fmt='${{ needs.fmt.result }}'
+          own='${{ needs.test.result }}'
+          fork='${{ needs.test-fork.result }}'
+          echo "fmt=$fmt test=$own test-fork=$fork"
+          [ "$fmt" = success ] || { echo "::error::rustfmt did not pass"; exit 1; }
+          # Exactly one of the two test paths runs per event.
+          if [ "$own" = success ] || [ "$fork" = success ]; then
+            echo "test suite ran and passed"
+          else
+            echo "::error::no test job succeeded (provider outage or test failure)"
+            exit 1
+          fi

--- a/src/cashu.rs
+++ b/src/cashu.rs
@@ -498,13 +498,15 @@ pub async fn mint_fresh_token(
         anyhow::bail!("cannot mint a zero-value token");
     }
 
-    let db = cdk_redb::wallet::WalletRedbDatabase::new(db_path).map_err(|e| {
-        anyhow::anyhow!(
-            "failed to open ephemeral wallet db at {}: {}",
-            db_path.display(),
-            e
-        )
-    })?;
+    let db = cdk_sqlite::WalletSqliteDatabase::new(db_path.to_path_buf())
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "failed to open ephemeral wallet db at {}: {}",
+                db_path.display(),
+                e
+            )
+        })?;
     let db: Arc<dyn WalletDatabase<Err = DbError> + Send + Sync> = Arc::new(db);
 
     let mut seed = [0u8; 64];

--- a/src/cli/commands/wallet.rs
+++ b/src/cli/commands/wallet.rs
@@ -51,7 +51,7 @@ async fn run_mint(args: MintArgs) -> Result<()> {
     // best-effort removal regardless of outcome.
     let mut db_path = std::env::temp_dir();
     db_path.push(format!(
-        "paygress-wallet-mint-{}.redb",
+        "paygress-wallet-mint-{}.sqlite",
         uuid::Uuid::new_v4()
     ));
 

--- a/src/lxd.rs
+++ b/src/lxd.rs
@@ -209,10 +209,24 @@ impl ComputeBackend for LxdBackend {
         Ok(())
     }
 
+    /// Idempotent: `lxc stop` exits non-zero on an already-stopped
+    /// instance, which is a normal state here — CI workloads power
+    /// themselves off when their job ends. Treating that as an error
+    /// would strand the container, since the cleanup path only
+    /// deletes after a successful stop.
     async fn stop_container(&self, id: u32) -> Result<()> {
         let name = format!("paygress-{}", id);
-        self.run_lxc(&["stop", &name])?;
-        Ok(())
+        match self.run_lxc(&["stop", &name]) {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                let msg = e.to_string().to_lowercase();
+                if msg.contains("already stopped") || msg.contains("not running") {
+                    Ok(())
+                } else {
+                    Err(e)
+                }
+            }
+        }
     }
 
     async fn delete_container(&self, id: u32) -> Result<()> {

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -907,11 +907,16 @@ impl ProviderService {
                 info!("Cleaning up expired workload: {}", vmid);
 
                 if let Some(_workload) = workloads.remove(&vmid) {
+                    // Delete unconditionally: the workload is already
+                    // out of the map, so a failed stop that skipped
+                    // the delete would leak the container AND its
+                    // vmid forever, with no retry. `delete --force`
+                    // handles running and stopped alike.
                     let stop_result = self.backend.stop_container(vmid).await;
-                    let result = match stop_result {
-                        Ok(_) => self.backend.delete_container(vmid).await,
-                        Err(e) => Err(e),
-                    };
+                    if let Err(e) = &stop_result {
+                        warn!("stop failed for {} ({}), deleting anyway", vmid, e);
+                    }
+                    let result = self.backend.delete_container(vmid).await;
 
                     // Untrack from the state machine regardless of
                     // backend stop/delete success — the lease is over,


### PR DESCRIPTION
Three fixes surfaced while wiring the repo's own CI onto Paygress runners. The first two are urgent; the third is hardening on the pipeline merged in #69.

## 1. `main` does not compile

#68 migrated the wallet from `cdk-redb` to `cdk-sqlite`; #69's `mint_fresh_token` landed on top still using `cdk_redb`, which #68 had already removed from `Cargo.toml`. The two PRs were fine independently and broke on merge.

```
error[E0433]: cannot find module or crate `cdk_redb`
   --> src/cashu.rs:501:14
```

`mint_fresh_token` now uses `cdk_sqlite::WalletSqliteDatabase` like `split_token_into_n` does, and the temp wallet filename follows suit (`.redb` → `.sqlite`).

Found the hard way: the first live run of the new CI pipeline failed at `cargo install --git`, which is the pipeline doing its job.

## 2. Expired containers (and their vmids) leak permanently

`cleanup_loop` deleted a container only when `stop_container` returned `Ok`:

```rust
let stop_result = self.backend.stop_container(vmid).await;
let result = match stop_result {
    Ok(_) => self.backend.delete_container(vmid).await,
    Err(e) => Err(e),
};
```

`lxc stop` exits non-zero on an already-stopped instance (verified on the CI box: `exit=1`), so any workload that stopped on its own never got deleted. That is now the normal path for CI runners, which `poweroff` when their single job ends to release compute early.

The consequences compound:

- the container and its disk survive expiry;
- `find_available_id` enumerates live `lxc list` output, so the vmid is consumed forever;
- the workload was already removed from `active_workloads` one line earlier, so nothing ever retries.

Every CI run leaks a container. At 1000 vmids the provider stops being able to spawn at all.

Fix: delete unconditionally (`delete --force` handles running and stopped alike) and log a warning if the stop failed; `LxdBackend::stop_container` treats "already stopped" / "not running" as success.

## 3. CI workflow hardening

- **`ci-gate` job** — `test`/`clippy` have `needs: spawn-runners`, so a provider outage marked them **skipped**, and a skipped required check reads as green: the PR looks tested when nothing ran. `ci-gate` is now the single required check and fails unless a test job actually succeeded.
- **Restore-only caches on rented compute** — `rust-cache` with `save-if: false`. A cache written from a rented box is a persistence channel that outlives the "one job, then gone" runner: poisoned build scripts and proc-macros would be restored and executed by later jobs, including hosted ones.
- **`persist-credentials: false`** — no job token sitting in `.git/config` on someone else's machine.
- **PAT via `env:` instead of argv** — Actions writes step command lines to disk and into the process table. `ci runner` already falls back to `$GITHUB_TOKEN`.
- **`concurrency` group with `cancel-in-progress`** — superseded pushes no longer mint and spend leases nobody will use.

## Verification

- `cargo test --all-features` — pass
- `cargo fmt --all -- --check` — clean
- `paygress-cli wallet mint --mint <ci-mint> --amount 100` — mints against the sqlite wallet
- `lxc stop` on a stopped instance returns 1, confirming the leak path
- workflow YAML parses

## Not addressed here

Larger items from the same review, worth their own issues: no per-npub admission control on the provider (any token from a whitelisted mint spawns a root container, and testnut mints are free), `handle_spawn_request` awaited inline in the DM loop so spawns serialize, no refund when provisioning fails after the token is redeemed, and no SSH host-key pinning (`StrictHostKeyChecking=no` with nothing to pin against).