### PR TITLE
fix(provider): don't evict non-replicated workloads on relay quorum loss

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,11 @@ name: CI
 # itself off, releasing the lease's compute). Dogfooding with teeth —
 # every push is a real spawn paid over the real protocol.
 #
-# Fork PRs never touch self-hosted runners: they run on the hosted
-# duplicates at the bottom. If the provider is down, spawn-runners
-# fails loud; fix the provider (or re-run) rather than papering over
-# it — outages are exactly the signal dogfooding exists to surface.
+# Fork PRs never touch self-hosted runners, and a repo without the
+# paygress config below runs everything hosted — both use the hosted
+# jobs at the bottom. A *configured* provider that is down still
+# fails loudly: outages are the signal dogfooding exists to surface,
+# whereas "not set up yet" is not a failure.
 #
 # Repo configuration this workflow expects:
 #   secrets.CI_RUNNER_PAT      fine-grained PAT, Administration: RW
@@ -51,7 +52,15 @@ jobs:
   spawn-runners:
     name: Spawn paygress runner (${{ matrix.target }})
     # Same-repo pushes and PRs only — fork PRs use the hosted jobs.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    # Needs the paygress config to exist. An unconfigured repo (fresh
+    # clone, or before the PAT is issued) falls back to hosted runners
+    # rather than failing — a missing variable is a configuration
+    # state, not a provider outage. A configured provider that is
+    # *down* still fails loudly, which is the signal worth having.
+    if: >-
+      vars.PAYGRESS_PROVIDER != '' &&
+      (github.event_name == 'push' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -176,9 +185,14 @@ jobs:
   # foot-gun; ephemeral single-job runners narrow it, this eliminates
   # it).
 
-  test-fork:
-    name: Test (fork, hosted)
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+  # Hosted fallback: fork PRs (never trust them on self-hosted) and
+  # repos with no paygress config yet.
+  test-hosted:
+    name: Test (hosted)
+    if: >-
+      vars.PAYGRESS_PROVIDER == '' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -189,9 +203,12 @@ jobs:
       - name: cargo test --all-features
         run: cargo test --all-features
 
-  clippy-fork:
-    name: Clippy (fork, hosted, advisory)
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+  clippy-hosted:
+    name: Clippy (hosted, advisory)
+    if: >-
+      vars.PAYGRESS_PROVIDER == '' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -206,23 +223,23 @@ jobs:
 
   # The single required check. Without it, a provider outage skips
   # `test` — and a skipped required check reads as green, i.e. the
-  # tests silently never ran. Skipped counts as failure here; only
-  # the fork/non-fork pair that was supposed to run may be skipped.
+  # tests silently never ran. Exactly one of the two test paths runs
+  # per event (paygress when configured, hosted otherwise), so the
+  # gate asserts that one of them actually passed.
   ci-gate:
     name: CI gate
     if: always()
-    needs: [fmt, test, clippy, test-fork, clippy-fork]
+    needs: [fmt, test, clippy, test-hosted, clippy-hosted]
     runs-on: ubuntu-latest
     steps:
       - name: Require tests to have actually run
         run: |
           fmt='${{ needs.fmt.result }}'
-          own='${{ needs.test.result }}'
-          fork='${{ needs.test-fork.result }}'
-          echo "fmt=$fmt test=$own test-fork=$fork"
+          paygress='${{ needs.test.result }}'
+          hosted='${{ needs.test-hosted.result }}'
+          echo "fmt=$fmt test(paygress)=$paygress test(hosted)=$hosted"
           [ "$fmt" = success ] || { echo "::error::rustfmt did not pass"; exit 1; }
-          # Exactly one of the two test paths runs per event.
-          if [ "$own" = success ] || [ "$fork" = success ]; then
+          if [ "$paygress" = success ] || [ "$hosted" = success ]; then
             echo "test suite ran and passed"
           else
             echo "::error::no test job succeeded (provider outage or test failure)"

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -102,4 +102,27 @@ pub trait ComputeBackend: Send + Sync {
 
     /// Get public IP of the container/VM
     async fn get_container_ip(&self, id: u32) -> Result<Option<String>>;
+
+    /// Whether the workload is still running.
+    ///
+    /// Distinguishes "the tenant's box is alive" from "the tenant's
+    /// box already terminated itself" — a CI runner powers off when
+    /// its single job ends. Callers use it to avoid destroying a
+    /// healthy container on an ambiguous signal.
+    ///
+    /// Defaults to `Running` so a backend that cannot answer never
+    /// causes a destructive action to be taken on its behalf.
+    async fn get_container_status(&self, _id: u32) -> Result<ContainerStatus> {
+        Ok(ContainerStatus::Running)
+    }
+}
+
+/// Coarse run state of a workload. Deliberately three-valued: an
+/// unreachable backend must not be mistaken for a stopped workload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContainerStatus {
+    Running,
+    Stopped,
+    /// The backend answered, but the workload is not in its list.
+    Absent,
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -28,7 +28,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use tokio::process::Command;
 
-use crate::compute::{ComputeBackend, ContainerConfig, NodeStatus};
+use crate::compute::{ComputeBackend, ContainerConfig, ContainerStatus, NodeStatus};
 use crate::luks::{create_encrypted_volume, destroy_encrypted_volume};
 
 /// Docker backend. Stateless wrapper around the `docker` CLI.
@@ -243,6 +243,23 @@ impl ComputeBackend for DockerBackend {
             disk_used: 0,
             disk_total: 0,
         })
+    }
+
+    async fn get_container_status(&self, id: u32) -> Result<ContainerStatus> {
+        let name = Self::name_for(id);
+        let output = self
+            .docker(&["inspect", "-f", "{{.State.Running}}", &name])
+            .await?;
+        if !output.status.success() {
+            // `inspect` fails only when there is no such container.
+            return Ok(ContainerStatus::Absent);
+        }
+        Ok(
+            match String::from_utf8_lossy(&output.stdout).trim().to_string() {
+                s if s == "true" => ContainerStatus::Running,
+                _ => ContainerStatus::Stopped,
+            },
+        )
     }
 
     async fn get_container_ip(&self, id: u32) -> Result<Option<String>> {

--- a/src/durable_workload.rs
+++ b/src/durable_workload.rs
@@ -310,6 +310,26 @@ fn workload_state_since(state: &WorkloadState) -> Option<u64> {
     }
 }
 
+/// Whether losing heartbeat quorum should push this workload toward
+/// eviction.
+///
+/// Quorum here is a **provider-level** signal: `send_heartbeat`
+/// publishes one heartbeat for the whole provider and records an
+/// observation per accepting relay, so "quorum lost" means *the
+/// provider could not reach enough relays*, not that any particular
+/// container is unhealthy.
+///
+/// That signal is only actionable for warm-standby: a standby needs
+/// it to take over, and the single-writer invariant depends on the
+/// primary evicting itself before the revocation is published. For
+/// every other workload there is no standby to promote — the
+/// consumer paid for wall-clock time, and a relay hiccup on the
+/// provider's side is not their problem. Evicting them would tear
+/// down healthy, paid-for containers during a network blip.
+fn failover_eligible(workload: &DurableWorkload) -> bool {
+    matches!(workload.replication, ReplicationMode::WarmStandby { .. })
+}
+
 fn advance(
     workload: &mut DurableWorkload,
     now: u64,
@@ -330,7 +350,7 @@ fn advance(
             if quorum_alive {
                 // refresh
                 workload.state = WorkloadState::Live { since };
-            } else if now.saturating_sub(since) >= cfg.t1_secs {
+            } else if failover_eligible(workload) && now.saturating_sub(since) >= cfg.t1_secs {
                 workload.state = WorkloadState::Suspect { since: now };
                 events.push(StateMachineEvent::EnteredSuspect {
                     workload_id: workload.workload_id,

--- a/src/lxd.rs
+++ b/src/lxd.rs
@@ -3,7 +3,7 @@
 // Implements ComputeBackend using the 'lxc' command line tool.
 // This is suitable for single-node setups like a VPS.
 
-use crate::compute::{ComputeBackend, ContainerConfig, NodeStatus};
+use crate::compute::{ComputeBackend, ContainerConfig, ContainerStatus, NodeStatus};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use std::process::Command;
@@ -207,6 +207,27 @@ impl ComputeBackend for LxdBackend {
         let name = format!("paygress-{}", id);
         self.run_lxc(&["start", &name])?;
         Ok(())
+    }
+
+    async fn get_container_status(&self, id: u32) -> Result<ContainerStatus> {
+        let name = format!("paygress-{}", id);
+        let raw = self.run_lxc(&["list", &format!("^{}$", name), "--format", "json"])?;
+        let containers = Self::parse_lxc_json(&raw)?;
+        let entry = containers.as_array().and_then(|a| {
+            a.iter()
+                .find(|c| c.get("name").and_then(|n| n.as_str()) == Some(&name))
+        });
+
+        Ok(match entry {
+            None => ContainerStatus::Absent,
+            Some(c) => match c.get("status").and_then(|s| s.as_str()) {
+                Some("Running") => ContainerStatus::Running,
+                // Stopped, Frozen, and anything else non-running are
+                // all "not serving the tenant" for our purposes.
+                Some(_) => ContainerStatus::Stopped,
+                None => ContainerStatus::Running,
+            },
+        })
     }
 
     /// Idempotent: `lxc stop` exits non-zero on an already-stopped

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -15,7 +15,7 @@ use tracing::{debug, error, info, warn};
 use crate::cashu::{
     resolve_wallet_seed, validate_and_redeem, CdkRedeemer, MintRedeemer, RedeemError,
 };
-use crate::compute::{ComputeBackend, ContainerConfig, PortMapping};
+use crate::compute::{ComputeBackend, ContainerConfig, ContainerStatus, PortMapping};
 use crate::docker::DockerBackend;
 use crate::durable_workload::{
     DurableWorkload, HeartbeatObservation, QuorumConfig, StateMachineEvent, WorkloadState,
@@ -876,9 +876,48 @@ impl ProviderService {
                 reason,
             } => {
                 error!("Workload {} marked Failed: {}", workload_id, reason);
-                // Drop from active_workloads so cleanup_loop doesn't
-                // also try to delete a container that was never
-                // successfully respawned.
+
+                // Once the workload leaves active_workloads, cleanup_loop
+                // can never see it again — so anything left behind here
+                // strands the container and burns its vmid for good
+                // (`find_available_id` reads live backend state).
+                //
+                // Only reclaim a container that has already terminated
+                // itself, which is what a CI runner does when its single
+                // job ends. A still-running box belongs to a consumer who
+                // paid through `expires_at`: leave it, and let the normal
+                // expiry sweep take it. Anything other than a definite
+                // "not running" answer errs toward leaving it alone.
+                match self.backend.get_container_status(workload_id).await {
+                    Ok(ContainerStatus::Stopped) => {
+                        if let Err(e) = self.backend.delete_container(workload_id).await {
+                            warn!(
+                                "failed to delete self-terminated workload {}: {}",
+                                workload_id, e
+                            );
+                        }
+                    }
+                    Ok(ContainerStatus::Absent) => {}
+                    Ok(ContainerStatus::Running) => {
+                        warn!(
+                            "workload {} failed but its container is still running; \
+                             leaving it to the expiry sweep",
+                            workload_id
+                        );
+                        // Keep it tracked so the sweep still owns it.
+                        return;
+                    }
+                    Err(e) => {
+                        warn!(
+                            "could not determine container status for failed workload {}: {} \
+                             — leaving it to the expiry sweep",
+                            workload_id, e
+                        );
+                        return;
+                    }
+                }
+
+                self.state_machine.lock().await.untrack(workload_id);
                 let mut wl = self.active_workloads.lock().await;
                 wl.remove(&workload_id);
             }

--- a/tests/durable_workload.rs
+++ b/tests/durable_workload.rs
@@ -46,6 +46,16 @@ fn workload(id: u32, provider: &str, replication: ReplicationMode, now: u64) -> 
     }
 }
 
+/// Heartbeat quorum is a provider-level signal, so only warm-standby
+/// workloads act on losing it — they have a standby to promote. Tests
+/// that exercise the Suspect / eviction path must therefore use this
+/// mode; `ReplicationMode::None` deliberately stays Live.
+fn warm_standby() -> ReplicationMode {
+    ReplicationMode::WarmStandby {
+        standby_providers: vec![PROVIDER_B.to_string()],
+    }
+}
+
 fn observation(provider: &str, relay: &str, when: u64) -> HeartbeatObservation {
     HeartbeatObservation {
         provider_npub: provider.to_string(),
@@ -107,7 +117,7 @@ fn live_stays_live_with_one_relay_silent() {
 #[test]
 fn live_transitions_to_suspect_after_t1_silence() {
     let mut sm = WorkloadStateMachine::new(quorum());
-    sm.track(workload(1, PROVIDER_A, ReplicationMode::None, 0));
+    sm.track(workload(1, PROVIDER_A, warm_standby(), 0));
     let _ = sm.tick(
         10,
         &RELAYS
@@ -127,7 +137,7 @@ fn live_transitions_to_suspect_after_t1_silence() {
 #[test]
 fn suspect_recovers_to_live_within_t2() {
     let mut sm = WorkloadStateMachine::new(quorum());
-    sm.track(workload(1, PROVIDER_A, ReplicationMode::None, 0));
+    sm.track(workload(1, PROVIDER_A, warm_standby(), 0));
     let _ = sm.tick(
         10,
         &RELAYS
@@ -151,7 +161,7 @@ fn suspect_recovers_to_live_within_t2() {
 #[test]
 fn suspect_evicts_after_t2_silence() {
     let mut sm = WorkloadStateMachine::new(quorum());
-    sm.track(workload(1, PROVIDER_A, ReplicationMode::None, 0));
+    sm.track(workload(1, PROVIDER_A, warm_standby(), 0));
     let _ = sm.tick(
         10,
         &RELAYS
@@ -175,6 +185,61 @@ fn suspect_evicts_after_t2_silence() {
     assert!(events
         .iter()
         .any(|e| matches!(e, StateMachineEvent::Evicted { workload_id: 1, .. })));
+}
+
+#[test]
+fn non_replicated_workload_survives_quorum_loss() {
+    // Quorum is a provider-level signal: it says the provider could
+    // not reach enough relays, NOT that this container is unhealthy.
+    // A `replication: none` consumer paid through `expires_at` and
+    // has no standby to promote, so a relay outage must not start
+    // tearing their workload down. Regression test: this path used to
+    // evict, and eviction dropped the workload without deleting the
+    // container — leaking it and burning its vmid.
+    let mut sm = WorkloadStateMachine::new(quorum());
+    sm.track(workload(1, PROVIDER_A, ReplicationMode::None, 0));
+    let _ = sm.tick(
+        10,
+        &RELAYS
+            .iter()
+            .map(|r| observation(PROVIDER_A, r, 10))
+            .collect::<Vec<_>>(),
+    );
+
+    // Total relay silence, well past both T1 and T2.
+    let _ = sm.tick(200, &[]);
+    let events = sm.tick(5000, &[]);
+
+    assert!(
+        matches!(sm.state_of(1), Some(WorkloadState::Live { .. })),
+        "non-replicated workload must stay Live through quorum loss; got {:?}",
+        sm.state_of(1)
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, StateMachineEvent::Evicted { .. })),
+        "no eviction event expected; got events={:?}",
+        events
+    );
+}
+
+#[test]
+fn checkpointed_workload_also_survives_quorum_loss() {
+    // Checkpointed has no standby either — same reasoning.
+    let mut sm = WorkloadStateMachine::new(quorum());
+    sm.track(workload(1, PROVIDER_A, ReplicationMode::Checkpointed, 0));
+    let _ = sm.tick(
+        10,
+        &RELAYS
+            .iter()
+            .map(|r| observation(PROVIDER_A, r, 10))
+            .collect::<Vec<_>>(),
+    );
+    let _ = sm.tick(200, &[]);
+    let _ = sm.tick(5000, &[]);
+
+    assert!(matches!(sm.state_of(1), Some(WorkloadState::Live { .. })));
 }
 
 #[test]
@@ -238,24 +303,25 @@ fn untrack_removes_workload() {
 
 #[test]
 fn respawn_failure_after_max_attempts_goes_to_failed() {
+    // Entered directly rather than driven through quorum loss:
+    // warm-standby evicts to a standby instead of respawning, and
+    // non-replicated workloads no longer evict on quorum at all, so
+    // nothing reaches Respawning today. The restart-policy logic is
+    // still worth pinning — the trigger it's waiting for is a
+    // container-health signal (the workload's own process dying),
+    // which the provider does not yet observe.
     let mut sm = WorkloadStateMachine::new(quorum());
     let mut wl = workload(1, PROVIDER_A, ReplicationMode::None, 0);
     wl.restart_policy = RestartPolicy::OnFailure { max_attempts: 1 };
+    wl.state = WorkloadState::Respawning {
+        since: 600,
+        attempts_used: 1,
+        last_error: None,
+    };
     sm.track(wl);
-    let _ = sm.tick(
-        10,
-        &RELAYS
-            .iter()
-            .map(|r| observation(PROVIDER_A, r, 10))
-            .collect::<Vec<_>>(),
-    );
-    let _ = sm.tick(200, &[]); // Suspect
-    let _ = sm.tick(600, &[]); // Evicted → Respawning
 
-    // First respawn attempt fails.
+    // The attempt fails, and max_attempts is already used up.
     sm.notify_respawn_failed(1, "backend down");
-    // After exhausting max_attempts the next tick must surface Failed.
-    let _ = sm.tick(1200, &[]);
 
     assert!(matches!(sm.state_of(1), Some(WorkloadState::Failed { .. })));
 }


### PR DESCRIPTION
Follow-up to #70, which fixed the expiry-path container leak. Watching the CI provider afterwards showed the leak still happening — through a different path, with a worse bug behind it.

## What the logs showed

```
12:12  Workload 2000 entered Live
12:14  Workload 2000 entered Suspect (heartbeat quorum lost)
12:19  Workload 2000 evicted: heartbeat-quorum-lost-past-t2
12:19  Attempting respawn (attempt 1)  →  "respawn handler not yet implemented"
       →  Failed  →  wl.remove(&workload_id)     // container never deleted
```

Eviction fires ~7 minutes after a CI runner powers off, long before its ~100 minute lease expires, so `cleanup_loop` never gets the chance #70 gave it.

## The bug behind the leak

Heartbeat quorum is a **provider-level** signal. `send_heartbeat` publishes one heartbeat for the whole provider and pushes one `HeartbeatObservation` per accepting relay (`provider.rs:545-572`); nothing in it is workload-specific. `quorum_alive` therefore means *the provider reached ≥m relays*, not *this container is healthy*.

`advance()` ran for every tracked workload regardless, so a relay hiccup walks **all** of a provider's tenants through Live → Suspect → Evicted. Workload 2000 was not evicted because it powered off — it was evicted because the provider's relay connections flapped.

That makes the obvious leak fix actively dangerous: deleting containers on `Failed` would have destroyed healthy, paid-for tenant containers during a routine relay outage.

## Changes

**1. Only warm-standby acts on quorum loss.** For warm-standby the signal is correct and load-bearing — the standby needs it to take over, and the single-writer invariant depends on the primary evicting itself before the revocation is published. For `None` / `Checkpointed` there is no standby to promote and the consumer paid through `expires_at`, so they stay Live and are reclaimed by the normal expiry sweep.

**2. `Failed` reclaims the container, but only when it has already stopped.** That is exactly the CI-runner case (poweroff after its single job). A still-running container belongs to a paying consumer and is left alone; so is any container whose status can't be determined. New `ComputeBackend::get_container_status` returning `Running` / `Stopped` / `Absent`, implemented for LXD and Docker, with a default of `Running` so a backend that cannot answer never causes a destructive action.

## Tests

`cargo test --all-features` — 17 suites green.

Three tests exercised the Suspect/eviction path using `ReplicationMode::None`; they now use warm-standby, which is the mode that path belongs to. Note one of them (`suspect_recovers_to_live_within_t2`) would have kept passing vacuously under the new semantics, since a non-replicated workload simply stays Live.

New: `non_replicated_workload_survives_quorum_loss` and `checkpointed_workload_also_survives_quorum_loss` — total relay silence well past T2, workload stays Live, no `Evicted` event.

`respawn_failure_after_max_attempts_goes_to_failed` now enters `Respawning` directly. Worth flagging: **the respawn path is currently unreachable in production.** Warm-standby evicts to a standby instead of respawning, and non-replicated workloads no longer evict on quorum, so nothing reaches `Respawning` until the provider observes container health directly. The restart-policy logic is still pinned by the test; the trigger it is waiting for does not exist yet.

## Follow-ups

- **Container-health monitoring** — the missing signal. Polling `get_container_status` (now on the trait) would let a crashed non-replicated workload legitimately reach `Respawning`, and would also let CI leases be reclaimed on job completion rather than at expiry.
- The respawn handler itself is still unimplemented (`provider.rs:860-872`).

## Deployment note

The provider binary on the CI VPS is dated 2026-05-10 and has none of these fixes. Nothing here or in #70 takes effect until `paygress-cli` is redeployed there and `paygress-provider-ci.service` restarted.