### PR TITLE
chore(deps): upgrade cdk 0.14 -> 0.17.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
 
 [[package]]
+name = "bitcoin-payment-instructions"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f5b43b0e8338cd36ce7940bd6b8a007d54f1cbe25314ec3fbba566f870b085"
+dependencies = [
+ "bitcoin",
+ "lightning",
+ "lightning-invoice",
+]
+
+[[package]]
 name = "bitcoin-units"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,9 +553,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cashu"
-version = "0.14.3"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61193273b0162fa16e74712d3d5cd2c02f13ddd8bf43a545c068feabd330895"
+checksum = "92e035322b7e279fc37a110e5fffdcf987fa5414caea1d0576cedb3b3611cbbb"
 dependencies = [
  "bitcoin",
  "cbor-diag",
@@ -552,7 +563,6 @@ dependencies = [
  "lightning",
  "lightning-invoice",
  "once_cell",
- "regex",
  "serde",
  "serde_json",
  "serde_with",
@@ -560,6 +570,7 @@ dependencies = [
  "strum_macros",
  "thiserror 2.0.18",
  "tracing",
+ "unicode-normalization",
  "url",
  "uuid",
  "web-time",
@@ -608,14 +619,15 @@ dependencies = [
 
 [[package]]
 name = "cdk"
-version = "0.14.3"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ad7dd8cef748cd57fdf83666c390c680f88cef79d3440e2f871c7da14dcb10"
+checksum = "89e19bcd47376859753f86adf4c2f661419ce619c777f92ac0a4e7c0594d4901"
 dependencies = [
  "anyhow",
  "arc-swap",
  "async-trait",
  "bitcoin",
+ "bitcoin-payment-instructions",
  "cbor-diag",
  "cdk-common",
  "cdk-signatory",
@@ -623,10 +635,10 @@ dependencies = [
  "futures",
  "getrandom 0.2.17",
  "gloo-timers",
+ "jsonwebtoken",
  "lightning",
  "lightning-invoice",
  "regex",
- "reqwest 0.12.28",
  "ring",
  "rustls",
  "serde",
@@ -634,7 +646,6 @@ dependencies = [
  "serde_with",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "url",
@@ -645,26 +656,30 @@ dependencies = [
 
 [[package]]
 name = "cdk-common"
-version = "0.14.3"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5427677f3b056fc6f799be8bd836ae35bad6e4123c99e3dd12972b1147c339"
+checksum = "7cb4f7239c3ed8ce35d8928324cf73147c802eb4f7cc42ef71827954cda96ac3"
 dependencies = [
  "anyhow",
  "async-trait",
  "bitcoin",
  "cashu",
  "cbor-diag",
+ "cdk-http-client",
  "ciborium",
  "futures",
  "getrandom 0.2.17",
+ "jsonwebtoken",
  "lightning",
  "lightning-invoice",
  "parking_lot",
+ "paste",
  "serde",
  "serde_json",
  "serde_with",
  "thiserror 2.0.18",
  "tokio",
+ "tonic",
  "tracing",
  "url",
  "uuid",
@@ -674,10 +689,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "cdk-signatory"
-version = "0.14.3"
+name = "cdk-http-client"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75f6d5f56de42d8948b442bc4092a2e59f9d4372fd6a17a575c374bf87cdc6a"
+checksum = "e6089ad04be877f3642729ab01a97b62e90a1ebafaac19583444fd72ffb2d25f"
+dependencies = [
+ "futures",
+ "futures-channel",
+ "js-sys",
+ "regex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio-tungstenite",
+ "tracing",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "cdk-signatory"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bed36ee68cff3260fca23fa485b2c9b31f2a15f6c045f62588c5db006c8964a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -697,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "cdk-sql-common"
-version = "0.14.3"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d5b94369ea3ef93e4396b3db541090fd188e15affda9119b15d1b7dcd885a2"
+checksum = "9ed515d34378fa51a5531882ea7c774f1f7af69bd4f50958c120c96f9159ac2f"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -716,15 +753,16 @@ dependencies = [
 
 [[package]]
 name = "cdk-sqlite"
-version = "0.14.3"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21b94615f42a150d8b4303e4a97e58db55febcf3cec1544360c47a09a54047c"
+checksum = "f96798d170b82f860daa83b2fc8f997151e6b77eb9f37c2ff4a92a7b5d650033"
 dependencies = [
  "async-trait",
  "bitcoin",
  "cdk-common",
  "cdk-sql-common",
  "lightning-invoice",
+ "paste",
  "rusqlite",
  "serde",
  "serde_json",
@@ -1130,6 +1168,9 @@ name = "dnssec-prover"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec4f825369fc7134da70ca4040fddc8e03b80a46d249ae38d9c1c39b7b4476bf"
+dependencies = [
+ "bitcoin_hashes",
+]
 
 [[package]]
 name = "dotenv"
@@ -2139,6 +2180,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "k8s-openapi"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2297,9 +2353,9 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.1.8"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ffe63f56b10d214be1ade8698ee80af82d981237cae3e581e7a631f5f4959f3"
+checksum = "63a1ab99a13ab3343a9b4d1d25c455bf72322819fc5a5f05c5182e704528a583"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -2307,15 +2363,16 @@ dependencies = [
  "hashbrown 0.13.2",
  "libm",
  "lightning-invoice",
+ "lightning-macros",
  "lightning-types",
  "possiblyrandom",
 ]
 
 [[package]]
 name = "lightning-invoice"
-version = "0.33.2"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
+checksum = "47d83bd798e04ab9eecc8bbef1fa17d3808859bcdc0406bd16c55d51c8834444"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -2324,10 +2381,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "lightning-types"
-version = "0.2.0"
+name = "lightning-macros"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
+checksum = "d4c717494cdc2c8bb85bee7113031248f5f6c64f8802b33c1c9e2d98e594aa71"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "lightning-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c211dfcff95ca308247da8b1e0e81604bc9e568239967cd2c34572558511e869"
 dependencies = [
  "bitcoin",
 ]
@@ -3832,6 +3900,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4197,6 +4277,26 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper 1.0.2",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,8 @@ rand = "0.8"
 
 # Cashu dependencies — cdk-sqlite matches ngx_l402's backend so both
 # processes share the same wallet database file for Lightning sweep.
-cdk-sqlite = { version = "0.14.1", features = ["wallet"] }
-cdk = { version = "0.14", default-features = false, features = ["wallet"] }
+cdk-sqlite = { version = "0.17.3", features = ["wallet"] }
+cdk = { version = "0.17.3", default-features = false, features = ["wallet"] }
 # BIP39 mnemonic -> 64-byte seed (Cashu/NUT-13). Must match ngx_l402_core's
 # derivation so the shared wallet opens identically in both processes.
 bip39 = { version = "2.1.0", features = ["unicode-normalization"] }

--- a/src/cashu.rs
+++ b/src/cashu.rs
@@ -40,7 +40,42 @@ const MSAT_PER_SAT: u64 = 1000;
 // `kubernetes` for the legacy K8s pipeline.
 static CASHU_DB: OnceLock<Arc<cdk_sqlite::WalletSqliteDatabase>> = OnceLock::new();
 
+/// redb's file header. Paygress stored the CDK wallet in redb until the
+/// switch to cdk-sqlite; the magic is what lets us recognize one of
+/// those files instead of handing it to a SQLite driver that reports
+/// only "file is not a database".
+const REDB_MAGIC: &[u8] = b"redb\x1a\x0a\xa9\x0d\x0a";
+
+/// Name a legacy redb wallet for what it is.
+///
+/// The wallet moved from redb to SQLite; a config still pointing at the
+/// old file gets "file is not a database" from the SQLite driver, which
+/// says neither what happened nor what to change. No migration is
+/// offered — there is nothing deployed to migrate — just a legible
+/// error.
+pub fn ensure_not_legacy_redb_wallet(db_path: &Path) -> anyhow::Result<()> {
+    use std::io::Read;
+
+    let Ok(mut file) = std::fs::File::open(db_path) else {
+        // Missing file is the normal first-run case: the driver creates it.
+        return Ok(());
+    };
+    let mut header = [0u8; REDB_MAGIC.len()];
+    if file.read_exact(&mut header).is_err() || header != REDB_MAGIC {
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "the cashu wallet at {} is a redb database; this version stores the \
+         wallet in SQLite. Point `cashu_wallet_db_path` at a new file, e.g. {}",
+        db_path.display(),
+        db_path.with_extension("sqlite").display(),
+    )
+}
+
 pub async fn initialize_cashu(db_path: &str) -> Result<(), String> {
+    ensure_not_legacy_redb_wallet(Path::new(db_path)).map_err(|e| e.to_string())?;
+
     match cdk_sqlite::WalletSqliteDatabase::new(std::path::PathBuf::from(db_path)).await {
         Ok(db) => {
             tracing::debug!("Cashu database initialized at: {}", db_path);
@@ -320,6 +355,61 @@ pub fn resolve_wallet_seed(nostr_private_key: &str) -> Result<[u8; 64], String> 
     }
     let mnemonic = mnemonic_from_nostr_key(nostr_private_key)?;
     derive_wallet_seed(&mnemonic)
+}
+
+#[cfg(test)]
+mod legacy_wallet_tests {
+    use super::*;
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "paygress-redb-test-{}-{}",
+            std::process::id(),
+            name
+        ));
+        p
+    }
+
+    #[test]
+    fn missing_file_is_fine() {
+        // First run: the SQLite driver creates the file itself.
+        let p = temp_path("absent.sqlite");
+        let _ = std::fs::remove_file(&p);
+        assert!(ensure_not_legacy_redb_wallet(&p).is_ok());
+    }
+
+    #[test]
+    fn redb_wallet_is_rejected_with_guidance() {
+        // Verbatim first bytes of a real paygress redb wallet.
+        let p = temp_path("legacy.redb");
+        std::fs::write(&p, b"redb\x1a\x0a\xa9\x0d\x0a\x03\x00\x00\x00").unwrap();
+
+        let err = ensure_not_legacy_redb_wallet(&p)
+            .expect_err("a redb wallet must not be opened as SQLite")
+            .to_string();
+        // Must name the format and the path to set instead.
+        assert!(err.contains("redb database"), "got: {}", err);
+        assert!(err.contains("legacy.sqlite"), "got: {}", err);
+
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn sqlite_and_short_files_pass_through() {
+        // A real SQLite wallet, and a file too short to hold the magic,
+        // both belong to the driver rather than this check.
+        let sqlite = temp_path("real.sqlite");
+        std::fs::write(&sqlite, b"SQLite format 3\x00rest").unwrap();
+        assert!(ensure_not_legacy_redb_wallet(&sqlite).is_ok());
+
+        let tiny = temp_path("tiny.sqlite");
+        std::fs::write(&tiny, b"ab").unwrap();
+        assert!(ensure_not_legacy_redb_wallet(&tiny).is_ok());
+
+        let _ = std::fs::remove_file(&sqlite);
+        let _ = std::fs::remove_file(&tiny);
+    }
 }
 
 #[cfg(test)]

--- a/src/cashu.rs
+++ b/src/cashu.rs
@@ -181,16 +181,13 @@ pub async fn validate_and_redeem<R: MintRedeemer + ?Sized>(
 /// (BIP39 / NUT-13 standard); tests can construct `CdkRedeemer` directly
 /// with any 64-byte seed.
 pub struct CdkRedeemer {
-    localstore: Arc<dyn WalletDatabase<Err = DbError> + Send + Sync>,
+    localstore: Arc<dyn WalletDatabase<DbError> + Send + Sync>,
     seed: [u8; 64],
     wallets: Mutex<HashMap<(String, CurrencyUnit), Arc<Wallet>>>,
 }
 
 impl CdkRedeemer {
-    pub fn new(
-        localstore: Arc<dyn WalletDatabase<Err = DbError> + Send + Sync>,
-        seed: [u8; 64],
-    ) -> Self {
+    pub fn new(localstore: Arc<dyn WalletDatabase<DbError> + Send + Sync>, seed: [u8; 64]) -> Self {
         Self {
             localstore,
             seed,
@@ -249,7 +246,10 @@ impl MintRedeemer for CdkRedeemer {
 
                 if is_keyset_err {
                     // Refresh keysets from the live mint, then retry once.
-                    let _ = wallet.get_mint_keysets().await;
+                    // `refresh_keysets` bypasses the metadata cache;
+                    // `get_mint_keysets` would serve the stale cache that
+                    // produced this error in the first place.
+                    let _ = wallet.refresh_keysets().await;
                     wallet
                         .receive(token_str, ReceiveOptions::default())
                         .await
@@ -459,7 +459,7 @@ mod wallet_seed_tests {
 ///
 /// Caveats:
 ///   - Exercised end-to-end against `testnut.cashu.space` only.
-///     The bundled cdk 0.14 wallet supports v2 (66-char) keyset
+///     The bundled cdk wallet supports v2 (66-char) keyset
 ///     IDs in code, so mainnet mints (e.g. `mint.minibits.cash`)
 ///     are expected to work for receive+split, but that path has
 ///     not been verified against a live mainnet mint yet.
@@ -514,7 +514,7 @@ pub async fn split_token_into_n(
                 e
             )
         })?;
-    let db: Arc<dyn WalletDatabase<Err = DbError> + Send + Sync> = Arc::new(db);
+    let db: Arc<dyn WalletDatabase<DbError> + Send + Sync> = Arc::new(db);
 
     // Random seed — the wallet is ephemeral, so deterministic
     // derivation buys us nothing. cdk's Wallet::new requires [u8; 64].
@@ -581,7 +581,7 @@ pub async fn mint_fresh_token(
     db_path: &Path,
 ) -> Result<String, anyhow::Error> {
     use cdk::amount::SplitTarget;
-    use cdk::nuts::MintQuoteState;
+    use cdk::nuts::{MintQuoteState, PaymentMethod};
     use rand::RngCore;
 
     if amount_sats == 0 {
@@ -597,7 +597,7 @@ pub async fn mint_fresh_token(
                 e
             )
         })?;
-    let db: Arc<dyn WalletDatabase<Err = DbError> + Send + Sync> = Arc::new(db);
+    let db: Arc<dyn WalletDatabase<DbError> + Send + Sync> = Arc::new(db);
 
     let mut seed = [0u8; 64];
     rand::thread_rng().fill_bytes(&mut seed);
@@ -606,7 +606,12 @@ pub async fn mint_fresh_token(
         .map_err(|e| anyhow::anyhow!("wallet construction failed: {}", e))?;
 
     let quote = wallet
-        .mint_quote(Amount::from(amount_sats), None)
+        .mint_quote(
+            PaymentMethod::BOLT11,
+            Some(Amount::from(amount_sats)),
+            None,
+            None,
+        )
         .await
         .map_err(|e| anyhow::anyhow!("mint quote request to {} failed: {}", mint_url, e))?;
 
@@ -617,11 +622,11 @@ pub async fn mint_fresh_token(
     const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
     let mut paid = false;
     for _ in 0..POLL_ATTEMPTS {
-        let state = wallet
-            .mint_quote_state(&quote.id)
+        let quote_status = wallet
+            .check_mint_quote_status(&quote.id)
             .await
             .map_err(|e| anyhow::anyhow!("mint quote status check failed: {}", e))?;
-        if state.state == MintQuoteState::Paid {
+        if quote_status.state == MintQuoteState::Paid {
             paid = true;
             break;
         }
@@ -662,7 +667,7 @@ pub async fn extract_token_value(token_str: &str) -> anyhow::Result<u64> {
     let token = Token::from_str(token_str)
         .map_err(|e| anyhow::anyhow!("Failed to decode Cashu token: {}", e))?;
 
-    // cdk 0.14 made `Token::proofs(&keysets)` require keyset metadata,
+    // cdk made `Token::proofs(&keysets)` require keyset metadata,
     // but `Token::value()` still works without — it's just the sum of
     // proof amounts. That's exactly what this legacy function does.
     let amount: Amount = token

--- a/src/cli/commands/batch.rs
+++ b/src/cli/commands/batch.rs
@@ -54,7 +54,7 @@ pub struct BatchArgs {
     /// value before fanning out spawns.
     ///
     /// Caveat: exercised end-to-end against `testnut.cashu.space`
-    /// only. The bundled cdk 0.14 wallet supports v2 (66-char)
+    /// only. The bundled cdk wallet supports v2 (66-char)
     /// keyset IDs in code, so mainnet mints (e.g.
     /// `mint.minibits.cash`) are expected to work, but that path
     /// has not been verified against a live mainnet mint yet.

--- a/src/cli/commands/provider.rs
+++ b/src/cli/commands/provider.rs
@@ -111,7 +111,7 @@ pub struct SetupArgs {
     /// Whitelisted Cashu mints (comma-separated). Defaults to
     /// `testnut.cashu.space` — the testnet mint paygress's
     /// integration paths exercise (`tests/cashu_redemption.rs`,
-    /// `tests/cli_deploy.rs`). The bundled cdk 0.14 wallet supports
+    /// `tests/cli_deploy.rs`). The bundled cdk wallet supports
     /// v2 keyset IDs in code, so mainnet mints (e.g.
     /// `https://mint.minibits.cash/Bitcoin`) are expected to work
     /// for receive+swap, but that flow has not been verified

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -354,6 +354,14 @@ impl ProviderService {
         // consistent proof history across restarts. Uses cdk-sqlite so the same
         // database file (and same seed) can be shared with ngx_l402, enabling it
         // to sweep Nostr-DM path ecash to Lightning alongside HTTP-path ecash.
+        // A provider upgrading across the redb → SQLite switch still has
+        // the old path in its config; refuse it with an explanation
+        // rather than letting the SQLite driver report "file is not a
+        // database".
+        crate::cashu::ensure_not_legacy_redb_wallet(std::path::Path::new(
+            &config.cashu_wallet_db_path,
+        ))?;
+
         let wallet_db = cdk_sqlite::WalletSqliteDatabase::new(std::path::PathBuf::from(
             &config.cashu_wallet_db_path,
         ))

--- a/tests/cashu_redemption.rs
+++ b/tests/cashu_redemption.rs
@@ -106,7 +106,7 @@ impl MintRedeemer for MockRedeemer {
         use std::str::FromStr;
         let token = cdk::nuts::Token::from_str(token_str)
             .map_err(|e| RedeemError::InvalidToken(e.to_string()))?;
-        // cdk 0.14: Token::value() returns the proof-amount sum without
+        // cdk: Token::value() returns the proof-amount sum without
         // requiring keyset metadata. We're not redeeming, just summing.
         let amount = token
             .value()


### PR DESCRIPTION
Unpins the mint.

Public testnut runs `cdk-mintd/0.17.0-rc.3`. Our 0.14 client could not parse its `/v1/info`:

```
Http Response error: data did not match any variant of untagged enum MintMethodOptions
```

So the only auto-paying mint our CI could use was the one we run ourselves on the CI VPS — the pipeline could switch providers with a config change, but not the money. This closes that.

## API changes

All in the wallet path, all in `src/cashu.rs`:

- **`WalletDatabase<Err = E>` → `WalletDatabase<E>`** — the error type moved from an associated type to a generic parameter (4 sites).
- **`mint_quote`** now takes `(PaymentMethod, Option<Amount>, description, extra)`. `PaymentMethod::BOLT11` is an associated const rather than a variant, because the enum gained a `Custom(String)` arm for non-Lightning methods.
- **`mint_quote_state` → `check_mint_quote_status`**.
- **`get_mint_keysets` now requires a `KeysetFilter`.** The keyset-error retry path switched to `refresh_keysets()` instead: it loads from the mint, whereas `get_mint_keysets` serves the metadata cache that produced the error in the first place. Closer to what that retry always meant.

## Verification

- `cargo test --all-features` — 17 suites green
- `cargo fmt --all -- --check` clean; no new clippy errors (warnings unchanged, still advisory)
- **Public testnut**: `wallet mint --mint https://testnut.cashu.space --amount 100` returns a valid token — previously impossible.
- **Old mint**: still mints against a `cdk-mintd/0.14.3` mint.
- **Cross-version wire compat**: a provider still running the 0.14 build accepted and redeemed a token minted by the 0.17 client, and provisioned the workload. So this can be rolled out to consumers and providers independently.

Stale `cdk 0.14` references in comments updated to be version-agnostic, so they don't rot on the next bump.