### PR TITLE
docs: README architecture diagrams, drop stale Kubernetes references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,38 @@ https://github.com/user-attachments/assets/627d2bb1-1a9b-4e66-bc42-7c91a1804fe1
 
 Paygress is a marketplace where anyone can buy or sell compute resources using Cashu ecash tokens. Providers advertise on Nostr, consumers discover and pay - all anonymous, all instant.
 
+```mermaid
+graph LR
+    C["Consumer<br/><i>paygress-cli</i>"]
+    R(("Nostr<br/>relays"))
+    P["Provider<br/><i>your Linux box</i>"]
+    W["Workload<br/><i>container or VM</i>"]
+    M["Cashu mint"]
+
+    C -->|"encrypted spawn request<br/>+ ecash token"| R
+    R --> P
+    P -->|"redeem token"| M
+    P -->|"provision"| W
+    P -->|"access details<br/>(encrypted DM)"| R
+    R --> C
+    C -.->|"SSH / HTTP"| W
+    P -.->|"offers + heartbeats"| R
+
+    style C fill:#1e3a5f,stroke:#4a9eff,color:#fff
+    style P fill:#1e4d2b,stroke:#4ade80,color:#fff
+    style W fill:#3d2f1e,stroke:#fbbf24,color:#fff
+    style M fill:#3d1e3d,stroke:#e879f9,color:#fff
+    style R fill:#2a2a3d,stroke:#a5b4fc,color:#fff
+```
+
+**No account exists anywhere in that picture.** The token is a bearer credential, the identity is a throwaway Nostr key, and the lease ends when the money runs out.
+
 ## What you can do
 
 In plain English, what Paygress lets a user do today:
 
 - **Rent a Linux container by the second.** Hand it a prepaid voucher, get a container running on someone else's machine. No signup, no credit card, no email. The container shuts down when the voucher runs out; extend the lease anytime by handing over another voucher.
-- **Pick from five ready-made boxes.** Generic Python + Node sandbox (with a built-in HTTP exec endpoint — run code without SSH); AI inference endpoint (Ollama, OpenAI-compatible API); Nostr relay; disposable headless Chrome; Bitcoin node.
+- **Pick from seven ready-made boxes.** Generic Python + Node sandbox (with a built-in HTTP exec endpoint — run code without SSH); AI inference endpoint (Ollama, OpenAI-compatible API); Nostr relay; disposable headless Chrome; Bitcoin node; OpenClaw; and a one-shot ngit CI runner.
 - **Run code inside the sandbox without SSH.** The agent-sandbox template ships with a bundled HTTP exec server. POST a command, get back stdout/stderr/exit code. Same credentials as SSH, no extra setup.
 - **Run many containers in parallel.** One command spawns N containers, splits a single voucher N ways automatically, hands you a JSON manifest with each one's address. Built for batch jobs (render farms, ML batch inference), CI matrices (one runner per OS/version), and map-reduce workloads.
 - **Long-running services with automatic failover.** Pay 3 hosts at once (one primary, two standbys). The primary runs the actual container and pings the network every minute. If it stops pinging — machine crashed, network died — the first standby takes over within ~30 seconds, becomes the new primary. (V1 caveat: best-effort single-writer for ~30s during failover; ideal for relays / stateless services, see PR #43 for the full story.)
@@ -73,6 +99,10 @@ paygress-cli spawn --provider 9f3d1e2a        ...   # 8-char prefix
 
 Get a Cashu token from a wallet like [Nutstash](https://nutstash.app/) or [Minibits](https://www.minibits.cash/), then:
 
+> **Just testing?** `paygress-cli wallet mint --mint https://testnut.cashu.space --amount 1000`
+> mints a token from a testnet mint whose fake Lightning backend auto-pays. It prints only
+> the token to stdout, so it composes: `--token "$(paygress-cli wallet mint …)"`.
+
 ```bash
 paygress-cli spawn \
   --provider <PROVIDER> \
@@ -96,15 +126,43 @@ ssh -p <PORT> root@<PROVIDER_IP>
 paygress-cli status --pod-id <ID> --provider <PROVIDER>
 ```
 
-### HTTP Mode
+### How a spawn actually works
 
-For centralized deployments (Kubernetes + Nginx L402 paywall), pass `--server` instead of `--provider`:
+```mermaid
+sequenceDiagram
+    participant C as Consumer
+    participant R as Nostr relays
+    participant P as Provider
+    participant M as Cashu mint
+    participant W as Workload
+
+    Note over C: token bought from any<br/>whitelisted mint
+    C->>R: NIP-17 encrypted spawn request<br/>(token, tier, image)
+    R->>P: delivered to provider's npub
+    P->>P: mint in whitelist?<br/>(checked before any network call)
+    P->>M: NUT-03 swap — redeem
+    M-->>P: value in msats
+    Note over P: lease = value ÷ rate<br/>e.g. 900 sats ÷ 150 msat/s = 100 min
+    P->>W: create container / VM
+    P->>R: access details (host, port, password)
+    R->>C: encrypted DM
+    C->>W: SSH / HTTP
+    Note over P,W: cleanup sweep destroys<br/>the workload at expiry
+```
+
+The whitelist check happens **before** the provider makes any network call, so a token pointed at an attacker-controlled mint never causes an outbound request.
+
+### HTTP mode
+
+Providers can also serve over HTTP behind [`ngx_l402`](https://github.com/DhananjayPurohit/ngx_l402), which validates and redeems the Cashu token at the nginx layer and sweeps accumulated ecash to Lightning. Pass `--server` instead of `--provider`:
 
 ```bash
 paygress-cli list --server http://my-server:8080
 paygress-cli spawn --server http://my-server:8080 --tier basic --token "cashuA..."
 paygress-cli status --server http://my-server:8080 --pod-id <ID>
 ```
+
+Both paths write into the same wallet, so a provider can run either or both.
 
 ---
 
@@ -208,20 +266,96 @@ Your provider is now reachable through the VPN tunnel. Consumers SSH to the tunn
 
 ---
 
-## Supported Backends
+## Compute backends
 
-| Backend | Best For | Status |
-|---------|----------|--------|
-| **LXD** | Ubuntu VPS, bare metal | Verified |
-| **Proxmox** | Home labs, Debian servers | Verified |
-| **Kubernetes** | Scalable cloud (HTTP/L402 mode) | Beta |
+A provider picks one backend at setup. It determines what the workload actually is — and therefore how strongly it's isolated.
+
+| Backend | What a workload is | Isolation | Requires |
+|---|---|---|---|
+| **LXD** | System container | `shared-kernel` | Ubuntu / bare metal |
+| **Proxmox** | LXC container | `shared-kernel` | Proxmox VE |
+| **Docker** | Docker container | `shared-kernel` | `docker` CLI — the only backend that runs the templates |
+| **KVM** | One qemu VM per spawn, own kernel | `dedicated-host` | `/dev/kvm`, `qemu-system-x86_64` |
+
+### Isolation tiers
+
+Providers advertise their tier; consumers filter on it with `--isolation-level`, and the CLI verifies the offer **before** spending the token.
+
+```mermaid
+graph TD
+    A["shared-kernel<br/><small>LXD · Proxmox · Docker</small>"]
+    B["dedicated-host<br/><small>KVM — one VM per workload</small>"]
+    C["attested-research-tier<br/><small>SEV-SNP / TDX</small>"]
+
+    A -->|"closes container escape<br/>and co-tenant attacks"| B
+    B -->|"closes the host operator"| C
+
+    A1["Cheapest. Tenants share the<br/>host kernel."]
+    B1["No co-tenants. Host operator<br/>can still read guest memory."]
+    C1["Not implemented — needs<br/>EPYC 7003+ / Sapphire Rapids."]
+
+    A -.- A1
+    B -.- B1
+    C -.- C1
+
+    style A fill:#4d2626,stroke:#f87171,color:#fff
+    style B fill:#4d3d1e,stroke:#fbbf24,color:#fff
+    style C fill:#1e4d2b,stroke:#4ade80,color:#fff
+    style A1 fill:none,stroke:none,color:#888
+    style B1 fill:none,stroke:none,color:#888
+    style C1 fill:none,stroke:none,color:#888
+```
+
+Stated plainly: on any tier below `attested-research-tier`, **the machine's operator can read your workload's memory and disk** — exactly as with any VPS provider. Paygress's difference is that you choose who that operator is.
 
 ## Architecture
 
-**Decentralized (Nostr + LXD/Proxmox):**
-Provider publishes offers (Kind 38383) and heartbeats (Kind 38384) to Nostr relays. Consumer sends encrypted spawn request with Cashu token. Provider verifies payment, creates container, returns SSH credentials - all via encrypted Nostr DMs.
+The control plane is Nostr; there is no paygress server in the middle.
 
-**Centralized (Kubernetes):**
-Nginx with `ngx_l402` validates Cashu tokens. Paygress provisions K8s pods with SSH access. Clients interact via HTTP API.
+```mermaid
+graph TB
+    subgraph consumer["Consumer side"]
+        CLI["paygress-cli"]
+        MCP["MCP server<br/><small>Claude, Cursor, Cline</small>"]
+    end
+
+    subgraph relays["Nostr relays"]
+        K1["kind 38383 — offers"]
+        K2["kind 38384 — heartbeats"]
+        DM["NIP-17 encrypted DMs<br/><small>spawn · topup · status</small>"]
+    end
+
+    subgraph provider["Provider"]
+        SVC["ProviderService"]
+        WAL["Cashu wallet<br/><small>SQLite, swept to Lightning</small>"]
+        STATE["Workload + standby state<br/><small>mirrored to disk</small>"]
+        BE["ComputeBackend"]
+    end
+
+    subgraph workloads["Workloads"]
+        T["7 templates<br/><small>relay · inference · browser<br/>bitcoin · sandbox · openclaw · ngit-runner</small>"]
+        RAW["or a bare box"]
+    end
+
+    CLI --> DM
+    MCP --> DM
+    K1 --> CLI
+    K2 --> CLI
+    DM <--> SVC
+    SVC --> K1
+    SVC --> K2
+    SVC --> WAL
+    SVC --> STATE
+    SVC --> BE
+    BE --> T
+    BE --> RAW
+
+    style consumer fill:#12263f,stroke:#4a9eff,color:#fff
+    style relays fill:#1f1f33,stroke:#a5b4fc,color:#fff
+    style provider fill:#14331f,stroke:#4ade80,color:#fff
+    style workloads fill:#332714,stroke:#fbbf24,color:#fff
+```
+
+**Provider durability.** Active leases and reserved standby slots are mirrored to disk on every change, so restarting a provider doesn't strand containers or forget who paid for what. Consumer volume-encryption keys are deliberately never written — they stay in memory for the life of the process.
 
 ---


### PR DESCRIPTION
The README had drifted from the code — it still advertised Kubernetes as a supported backend after that feature was deleted, listed two of the four real backends, and had no way to get a token to try anything with.

## Diagrams

Four, all mermaid. GitHub renders them natively, so there are no image files to keep in sync with the code and the diagrams stay reviewable in a diff.

1. **System overview**, directly under the tagline — consumer → relays → provider → workload, with the mint to one side. The shape of the thing before any prose.
2. **Spawn sequence** — where the money actually moves: whitelist check → NUT-03 redeem → `lease = value ÷ rate` → provision → encrypted DM back. Hardest part to convey in prose, easiest in a sequence diagram.
3. **Isolation tiers** — the ladder, with what each tier closes and what it does not.
4. **Component view** — the control plane, making it visible that no paygress server sits in the middle.

## Corrections

- **Kubernetes removed** from the backend table (it was listed as "Beta") and from the architecture section, which described a "Centralized (Kubernetes)" deployment that no longer exists. Verified zero remaining references.
- **Backend table now lists all four** — LXD, Proxmox, Docker, KVM — with what a workload actually *is* on each (system container / LXC / Docker container / one qemu VM per spawn) and the isolation tier it yields. That is the thing a consumer chooses on, and it was absent.
- **HTTP mode** is described as `ngx_l402` rather than "centralized Kubernetes", with a note that both paths share one wallet.
- **Seven templates, not five** — the count had not been updated for `openclaw` and `ngit-runner`.
- **`wallet mint` added.** There was previously no documented way to obtain a token to test with; the callout shows the testnut one-liner and notes that it prints only the token to stdout, so it composes into `--token "$(…)"`.
- **Provider durability** noted: leases and standby slots are mirrored to disk, so a restart doesn't strand containers, and consumer volume-encryption keys are deliberately never written.

## One deliberate wording choice

The isolation section now states plainly that on any tier below `attested-research-tier` **the machine's operator can read the workload's memory and disk — as with any VPS provider** — and that paygress's difference is letting you choose who that operator is.

That is less flattering than the previous text, but it is accurate, and it is better for a reader to find it here than to discover it themselves and wonder what else was oversold.

Positioning is otherwise untouched.