### PR TITLE
Blossom size probing, and nesting as a provider's choice

### DIFF
--- a/src/blossom.rs
+++ b/src/blossom.rs
@@ -1,5 +1,6 @@
 // Blossom client — the BUD-01/02/04 subset needed for warm-standby
-// checkpoint storage: PUT /upload, GET /<sha256>, DELETE /<sha256>.
+// checkpoint storage: PUT /upload, GET /<sha256>, DELETE /<sha256>,
+// plus the BUD-06 HEAD /upload pre-flight.
 //
 // Auth is a NIP-98-style kind-24242 Nostr event, base64-JSON in
 // `Authorization: Nostr <b64>`, tagged with the operation (`t`), the
@@ -54,6 +55,27 @@ pub struct UploadResponse {
     pub uploaded: u64,
 }
 
+/// `HEAD /upload` outcome (BUD-06). A refusal is an answer, not an error, so
+/// the status travels back intact instead of being flattened into `Err`.
+#[derive(Debug, Clone)]
+pub struct UploadCheck {
+    pub status: u16,
+    /// `X-Reason`, the server's human-readable explanation when it says no.
+    pub reason: Option<String>,
+}
+
+impl UploadCheck {
+    pub fn accepted(&self) -> bool {
+        (200..300).contains(&self.status)
+    }
+
+    /// Servers that never implemented BUD-06 answer the probe itself, not the
+    /// question — treating that as a refusal would rule out a usable server.
+    pub fn unsupported(&self) -> bool {
+        matches!(self.status, 404 | 405 | 501)
+    }
+}
+
 impl BlossomClient {
     pub fn new(server: impl Into<String>, keys: Keys) -> Self {
         Self {
@@ -95,6 +117,42 @@ impl BlossomClient {
 
         let parsed: UploadResponse = resp.json().await.context("parse Blossom upload response")?;
         Ok(parsed)
+    }
+
+    /// Ask whether the server would accept a blob of this size and hash before
+    /// spending the bandwidth to find out (BUD-06). The authorization event is
+    /// the same one `put` would send — an unsigned probe is rejected with 401
+    /// before the size is ever looked at.
+    pub async fn check_upload(
+        &self,
+        sha256: &str,
+        size: u64,
+        mime_type: Option<&str>,
+    ) -> Result<UploadCheck> {
+        let auth = self.build_auth_header(BlossomOp::Upload, sha256).await?;
+        let url = format!("{}/upload", self.server);
+
+        let mut req = self
+            .http
+            .head(&url)
+            .header("Authorization", auth)
+            .header("X-SHA-256", sha256)
+            .header("X-Content-Length", size.to_string());
+        if let Some(mime) = mime_type {
+            req = req.header("X-Content-Type", mime);
+        }
+
+        let resp = req.send().await.with_context(|| format!("HEAD {}", url))?;
+        let reason = resp
+            .headers()
+            .get("X-Reason")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+
+        Ok(UploadCheck {
+            status: resp.status().as_u16(),
+            reason,
+        })
     }
 
     /// Fetch by hash. Bytes are still encrypted.

--- a/src/cli/commands/blossom.rs
+++ b/src/cli/commands/blossom.rs
@@ -1,0 +1,260 @@
+// `blossom check-upload` answers one question before a big blob is built:
+// would this server take it? BUD-06's HEAD /upload needs a signed kind-24242
+// event — an unsigned probe returns 401 without the size ever being read —
+// so it goes through the client in `paygress::blossom`, not curl.
+
+use anyhow::{Context, Result};
+use clap::{Args, Subcommand};
+use colored::Colorize;
+use nostr_sdk::Keys;
+
+use paygress::blossom::BlossomClient;
+use paygress::blossom_crypto::sha256_hex;
+
+#[derive(Args)]
+pub struct BlossomArgs {
+    #[command(subcommand)]
+    pub action: BlossomAction,
+}
+
+#[derive(Subcommand)]
+pub enum BlossomAction {
+    /// Ask servers whether they would accept a blob of a given size (BUD-06)
+    CheckUpload(CheckUploadArgs),
+
+    /// Upload a file and print its content address
+    Upload(UploadArgs),
+
+    /// Delete a blob by hash
+    Delete(DeleteArgs),
+}
+
+#[derive(Args)]
+pub struct UploadArgs {
+    /// Blossom server to upload to.
+    #[arg(long)]
+    pub server: String,
+
+    /// File to upload. Sent as-is — wrap it in `blossom_crypto` first if the
+    /// server should not see the contents.
+    #[arg(long)]
+    pub file: std::path::PathBuf,
+
+    /// Sign with this key instead of an ephemeral one. An ephemeral key can
+    /// upload but can never delete afterwards.
+    #[arg(long)]
+    pub nsec: Option<String>,
+}
+
+#[derive(Args)]
+pub struct DeleteArgs {
+    /// Blossom server holding the blob.
+    #[arg(long)]
+    pub server: String,
+
+    /// Content address of the blob to remove.
+    #[arg(long)]
+    pub hash: String,
+
+    /// Must be the key that uploaded it.
+    #[arg(long)]
+    pub nsec: String,
+}
+
+#[derive(Args)]
+pub struct CheckUploadArgs {
+    /// Blossom server to probe. Repeat to compare several.
+    #[arg(long = "server", required = true)]
+    pub servers: Vec<String>,
+
+    /// Blob size in bytes. Suffixes are accepted: 183MB, 1.5GB, 200KB.
+    #[arg(long, conflicts_with = "file", required_unless_present = "file")]
+    pub size: Option<String>,
+
+    /// Probe with a real blob's size and hash instead of a hypothetical one.
+    #[arg(long)]
+    pub file: Option<std::path::PathBuf>,
+
+    /// MIME type sent as `X-Content-Type`.
+    #[arg(long, default_value = "application/octet-stream")]
+    pub mime: String,
+
+    /// Sign with this key instead of an ephemeral one, for servers that
+    /// only accept uploads from known pubkeys.
+    #[arg(long)]
+    pub nsec: Option<String>,
+}
+
+pub async fn execute(args: BlossomArgs, verbose: bool) -> Result<()> {
+    match args.action {
+        BlossomAction::CheckUpload(a) => run_check_upload(a, verbose).await,
+        BlossomAction::Upload(a) => run_upload(a).await,
+        BlossomAction::Delete(a) => run_delete(a).await,
+    }
+}
+
+async fn run_upload(args: UploadArgs) -> Result<()> {
+    let keys = match &args.nsec {
+        Some(nsec) => Keys::parse(nsec).context("parsing --nsec")?,
+        None => Keys::generate(),
+    };
+
+    let bytes = std::fs::read(&args.file).with_context(|| format!("reading {:?}", args.file))?;
+    eprintln!(
+        "{} uploading {} bytes to {}",
+        "→".blue(),
+        bytes.len(),
+        args.server
+    );
+
+    let expected = sha256_hex(&bytes);
+    let resp = BlossomClient::new(args.server.clone(), keys)
+        .put(bytes)
+        .await?;
+    if resp.sha256 != expected {
+        anyhow::bail!(
+            "server returned hash {} for bytes hashing to {}",
+            resp.sha256,
+            expected
+        );
+    }
+
+    eprintln!("{} stored {} bytes", "✓".green(), resp.size);
+    // The URL is the entire stdout contract.
+    println!("{}", resp.url);
+    Ok(())
+}
+
+async fn run_delete(args: DeleteArgs) -> Result<()> {
+    let keys = Keys::parse(&args.nsec).context("parsing --nsec")?;
+    BlossomClient::new(args.server.clone(), keys)
+        .delete(&args.hash)
+        .await?;
+    eprintln!("{} deleted {}", "✓".green(), args.hash);
+    Ok(())
+}
+
+async fn run_check_upload(args: CheckUploadArgs, verbose: bool) -> Result<()> {
+    let keys = match &args.nsec {
+        Some(nsec) => Keys::parse(nsec).context("parsing --nsec")?,
+        None => Keys::generate(),
+    };
+
+    // A hypothetical blob still needs a hash to put in the `x` tag; servers
+    // check the signature and the size, not whether the bytes exist yet.
+    let (size, hash) = match &args.file {
+        Some(path) => {
+            let bytes = std::fs::read(path).with_context(|| format!("reading {:?}", path))?;
+            (bytes.len() as u64, sha256_hex(&bytes))
+        }
+        None => {
+            let size = parse_size(args.size.as_deref().unwrap_or_default())?;
+            (
+                size,
+                sha256_hex(format!("paygress-probe-{}", size).as_bytes()),
+            )
+        }
+    };
+
+    if verbose {
+        eprintln!(
+            "{} probing {} bytes as {} ({})",
+            "→".blue(),
+            size,
+            &hash[..16],
+            keys.public_key().to_hex()
+        );
+    }
+
+    let mut any_accepted = false;
+    for server in &args.servers {
+        let client = BlossomClient::new(server.clone(), keys.clone());
+        match client.check_upload(&hash, size, Some(&args.mime)).await {
+            Ok(check) if check.accepted() => {
+                any_accepted = true;
+                println!("{} {} accepts {} bytes", "✓".green(), server, size);
+            }
+            Ok(check) if check.unsupported() => {
+                println!(
+                    "{} {} does not implement BUD-06 (HTTP {}) — size limit unknown",
+                    "?".yellow(),
+                    server,
+                    check.status
+                );
+            }
+            Ok(check) => {
+                println!(
+                    "{} {} refuses {} bytes (HTTP {}{})",
+                    "✗".red(),
+                    server,
+                    size,
+                    check.status,
+                    check
+                        .reason
+                        .as_deref()
+                        .map(|r| format!(": {}", r))
+                        .unwrap_or_default()
+                );
+            }
+            Err(e) => {
+                println!("{} {} unreachable: {}", "✗".red(), server, e);
+            }
+        }
+    }
+
+    if !any_accepted {
+        anyhow::bail!("no probed server confirmed it would accept {} bytes", size);
+    }
+    Ok(())
+}
+
+/// Bytes, or a decimal with a KB/MB/GB suffix (powers of 1024, as every
+/// blob-size limit in the wild is quoted).
+fn parse_size(raw: &str) -> Result<u64> {
+    let s = raw.trim();
+    let (digits, multiplier) = match s.to_ascii_uppercase() {
+        u if u.ends_with("GB") => (&s[..s.len() - 2], 1024u64 * 1024 * 1024),
+        u if u.ends_with("MB") => (&s[..s.len() - 2], 1024 * 1024),
+        u if u.ends_with("KB") => (&s[..s.len() - 2], 1024),
+        u if u.ends_with('B') => (&s[..s.len() - 1], 1),
+        _ => (s, 1),
+    };
+
+    let value: f64 = digits
+        .trim()
+        .parse()
+        .with_context(|| format!("cannot read {:?} as a size", raw))?;
+    if !value.is_finite() || value < 0.0 {
+        anyhow::bail!("size must be a positive number, got {:?}", raw);
+    }
+    Ok((value * multiplier as f64).round() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_size;
+
+    #[test]
+    fn plain_digits_are_bytes() {
+        assert_eq!(parse_size("183").unwrap(), 183);
+    }
+
+    #[test]
+    fn suffixes_are_binary_multiples() {
+        assert_eq!(parse_size("1KB").unwrap(), 1024);
+        assert_eq!(parse_size("183MB").unwrap(), 183 * 1024 * 1024);
+        assert_eq!(parse_size("1.5GB").unwrap(), 1024 * 1024 * 1024 * 3 / 2);
+    }
+
+    #[test]
+    fn suffixes_are_case_insensitive() {
+        assert_eq!(parse_size("2mb").unwrap(), 2 * 1024 * 1024);
+    }
+
+    #[test]
+    fn garbage_is_rejected() {
+        assert!(parse_size("big").is_err());
+        assert!(parse_size("-1MB").is_err());
+        assert!(parse_size("").is_err());
+    }
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod adapter;
 pub mod batch;
+pub mod blossom;
 pub mod bootstrap;
 pub mod deploy;
 pub mod exec;

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -7,8 +7,8 @@ mod exec_client;
 mod util;
 
 use commands::{
-    adapter, batch, bootstrap, deploy, exec, list, mcp, provider, spawn, status, system, topup,
-    wallet,
+    adapter, batch, blossom, bootstrap, deploy, exec, list, mcp, provider, spawn, status, system,
+    topup, wallet,
 };
 
 /// Paygress CLI - Pay-per-Use Compute with Lightning + Nostr
@@ -58,6 +58,9 @@ enum Commands {
     /// Local token utilities
     Wallet(wallet::WalletArgs),
 
+    /// Blossom blob storage utilities
+    Blossom(blossom::BlossomArgs),
+
     /// Provider management - setup, start, stop, status
     Provider(provider::ProviderArgs),
 
@@ -106,6 +109,7 @@ async fn main() {
         Commands::Adapter(args) => adapter::execute(args, cli.verbose).await,
         Commands::Exec(args) => exec::execute(args, cli.verbose).await,
         Commands::Wallet(args) => wallet::execute(args).await,
+        Commands::Blossom(args) => blossom::execute(args, cli.verbose).await,
         Commands::Provider(args) => provider::execute(args, cli.verbose).await,
         Commands::Bootstrap(args) => bootstrap::execute(args, cli.verbose).await,
         Commands::System(args) => system::execute(args, cli.verbose).await,

--- a/src/lxd.rs
+++ b/src/lxd.rs
@@ -10,14 +10,35 @@ use tracing::info;
 
 pub struct LxdBackend {
     storage_pool: String,
+    /// Whether launched containers may run containers of their own.
+    nesting: bool,
+}
+
+/// Whether a provider advertising `capabilities` is offering nested containers.
+///
+/// Kept next to the code that acts on it, and matched case-insensitively
+/// because these strings are hand-written in provider config files. A typo
+/// costs the provider CI work rather than granting something it did not mean
+/// to, which is the right way round for a capability that lets a renter run
+/// containers.
+pub fn nesting_from_capabilities<S: AsRef<str>>(capabilities: &[S]) -> bool {
+    capabilities
+        .iter()
+        .any(|c| c.as_ref().trim().eq_ignore_ascii_case("nesting"))
 }
 
 impl LxdBackend {
     /// `network_device` is unused: containers get their NIC from LXD's default
     /// profile.
-    pub fn new(storage_pool: &str, _network_device: &str) -> Self {
+    ///
+    /// `nesting` decides whether workloads may run containers of their own. It
+    /// comes from the provider advertising the `nesting` capability rather than
+    /// from a separate setting, so what an offer claims and what a container
+    /// can actually do cannot drift apart.
+    pub fn new(storage_pool: &str, _network_device: &str, nesting: bool) -> Self {
         Self {
             storage_pool: storage_pool.to_string(),
+            nesting,
         }
     }
 
@@ -145,20 +166,20 @@ impl ComputeBackend for LxdBackend {
         let pool = self.resolve_storage_pool().await?;
         info!("Using storage pool: {}", pool);
 
-        self.run_lxc(&[
-            "launch",
-            image,
-            &name,
-            "-s",
-            &pool,
-            "-c",
-            &cpu_limit,
-            "-c",
-            &mem_limit,
-            "-c",
-            "security.nesting=true",
-        ])
-        .await?;
+        // Nesting is what lets a workload run its own containers — a CI job
+        // needing docker-in-docker cannot work without it. It is also a real
+        // grant: with it, everything the renter runs can create containers. So
+        // it is the provider's call, expressed by advertising the capability,
+        // and off for providers that do not.
+        let mut args = vec![
+            "launch", image, &name, "-s", &pool, "-c", &cpu_limit, "-c", &mem_limit,
+        ];
+        if self.nesting {
+            args.push("-c");
+            args.push("security.nesting=true");
+        }
+
+        self.run_lxc(&args).await?;
 
         // Retry while the container finishes booting. The credential goes over
         // stdin, never through a shell.
@@ -343,5 +364,41 @@ impl ComputeBackend for LxdBackend {
         }
 
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::nesting_from_capabilities;
+
+    #[test]
+    fn advertising_nesting_enables_it() {
+        assert!(nesting_from_capabilities(&[
+            "lxc", "vm", "nesting", "docker"
+        ]));
+    }
+
+    #[test]
+    fn not_advertising_nesting_leaves_it_off() {
+        // The default provider config advertises only "lxc", so an operator who
+        // never opted in must not be handing out nesting.
+        assert!(!nesting_from_capabilities(&["lxc"]));
+        assert!(!nesting_from_capabilities::<&str>(&[]));
+    }
+
+    #[test]
+    fn matching_ignores_case_and_padding() {
+        assert!(nesting_from_capabilities(&["Nesting"]));
+        assert!(nesting_from_capabilities(&[" nesting "]));
+    }
+
+    // "nested" is not "nesting": a near-miss must not grant the capability.
+    #[test]
+    fn near_misses_do_not_grant_it() {
+        assert!(!nesting_from_capabilities(&[
+            "nested",
+            "nest",
+            "nesting-vm"
+        ]));
     }
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -90,6 +90,11 @@ impl ProviderService {
             BackendType::LXD => Arc::new(LxdBackend::new(
                 &config.proxmox_storage, // storage field doubles as the pool name
                 &config.proxmox_bridge,  // bridge field doubles as the network
+                // A provider that advertises `nesting` is promising workloads
+                // can run containers; one that does not gets containers that
+                // cannot. Reading it from the same list the offer carries keeps
+                // the promise and the grant in step.
+                crate::lxd::nesting_from_capabilities(&config.capabilities),
             )),
             BackendType::Docker => Arc::new(DockerBackend::new()),
             BackendType::Kvm => {

--- a/tests/blossom.rs
+++ b/tests/blossom.rs
@@ -3,7 +3,7 @@
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use nostr_sdk::Keys;
-use wiremock::matchers::{header_exists, method, path, path_regex};
+use wiremock::matchers::{header, header_exists, method, path, path_regex};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use paygress::blossom::{BlossomClient, BlossomOp};
@@ -128,6 +128,68 @@ async fn upload_5xx_is_surfaced_as_error() {
         "error must surface server status, got: {}",
         msg
     );
+}
+
+#[tokio::test]
+async fn check_upload_sends_signed_bud06_headers() {
+    let (server, client) = stub_server().await;
+
+    let hash = "a".repeat(64);
+    Mock::given(method("HEAD"))
+        .and(path("/upload"))
+        .and(header_exists("authorization"))
+        .and(header("x-sha-256", hash.as_str()))
+        .and(header("x-content-length", "191889408"))
+        .and(header("x-content-type", "application/octet-stream"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let check = client
+        .check_upload(&hash, 191_889_408, Some("application/octet-stream"))
+        .await
+        .expect("probe completes");
+    assert!(check.accepted());
+    assert!(!check.unsupported());
+}
+
+#[tokio::test]
+async fn check_upload_reports_refusal_with_reason_instead_of_erroring() {
+    let (server, client) = stub_server().await;
+
+    Mock::given(method("HEAD"))
+        .and(path("/upload"))
+        .respond_with(
+            ResponseTemplate::new(413).insert_header("X-Reason", "File too large, max 100MB"),
+        )
+        .mount(&server)
+        .await;
+
+    let check = client
+        .check_upload(&"b".repeat(64), 191_889_408, None)
+        .await
+        .expect("a refusal is an answer, not a transport error");
+    assert_eq!(check.status, 413);
+    assert!(!check.accepted());
+    assert_eq!(check.reason.as_deref(), Some("File too large, max 100MB"));
+}
+
+#[tokio::test]
+async fn check_upload_flags_servers_without_bud06_as_unsupported() {
+    let (server, client) = stub_server().await;
+
+    Mock::given(method("HEAD"))
+        .and(path("/upload"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let check = client
+        .check_upload(&"c".repeat(64), 1024, None)
+        .await
+        .expect("probe completes");
+    assert!(check.unsupported(), "404 must not read as a size refusal");
+    assert!(!check.accepted());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Two changes that came out of running the ngit-ci pipeline on paid sandboxes for real.

## Probe a Blossom server before trusting it with a blob

The CI build cache is ~183 MB and has to live somewhere reachable from any provider's sandbox, so we need to know which Blossom servers will take a blob that size. BUD-06 answers exactly that with `HEAD /upload`, but only for a signed kind-24242 event — an unsigned probe returns 401 before the size is ever read, which is why this belongs in the client rather than in curl.

`check_upload` returns the status rather than an `Err`: a refusal is the answer, and 404/405 ("never implemented BUD-06") has to stay distinguishable from a real no, or a usable server gets ruled out for the wrong reason.

`blossom upload` / `blossom delete` exist because **the probe is not proof**. Measured against real servers:

| server | answer at 183 MB |
| ------ | ---------------- |
| nostr.download | accepts; ceiling between 8 and 16 GB |
| blossom.primal.net | 200 to anything, including 100 GB — then 415s a real 10 MB upload |
| blossom.band | 413, "maximum allowed size of 100 MiB" |
| nostrcheck.me | 413, payload too large |
| cdn.satellite.earth | no BUD-06 (404), limit unknown |

primal answering 200 to a 100 GB preflight and then rejecting a real upload on the MIME type is the reason both halves are here. Verified end to end on nostr.download: 183 MB uploaded, fetched back, hash matched, deleted.

This also turned out to matter beyond the cache: ngit-ci uploads artifacts with an `application/octet-stream` fallback, which is the exact content type primal refuses.

## Nesting is the provider's choice

`security.nesting=true` was set on every LXD container unconditionally, so every renter could run containers whether the operator intended it or not. A CI job doing docker-in-docker needs exactly that — which is why it was there — but it is a real grant and it should be the provider's call.

It is derived from the provider advertising the `nesting` capability rather than from a new setting of its own. An offer that claims nesting while the container cannot nest is the failure mode worth designing out: the adapter picks providers it has never used, and a job dying at dockerd startup on a provider that advertised nesting reads as a CI bug rather than a config mismatch. One source of truth keeps the promise and the grant in step.

Matching is case-insensitive and trimmed, since these strings are hand-written in provider configs, and a near-miss like `nested` deliberately does not grant it — a typo should cost the provider work, not hand out a capability it did not mean to.

**Behaviour change:** providers whose config does not list `nesting` stop getting it. That is the honest reading of their own advertisement, and the default config has only ever advertised `lxc`.

## Checks

298 tests pass, fmt clean, clippy unchanged apart from the pre-existing `ProviderAction` `large_enum_variant`.